### PR TITLE
 Use internal endpoint to interact with Keystone

### DIFF
--- a/controllers/designateapi_controller.go
+++ b/controllers/designateapi_controller.go
@@ -661,13 +661,18 @@ func (r *DesignateAPIReconciler) generateServiceConfigMaps(
 	if err != nil {
 		return err
 	}
-	authURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointPublic)
+	keystoneInternalURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointInternal)
+	if err != nil {
+		return err
+	}
+	keystonePublicURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointPublic)
 	if err != nil {
 		return err
 	}
 	templateParameters := make(map[string]interface{})
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
-	templateParameters["KeystonePublicURL"] = authURL
+	templateParameters["KeystoneInternalURL"] = keystoneInternalURL
+	templateParameters["KeystonePublicURL"] = keystonePublicURL
 
 	cms := []util.Template{
 		// ScriptsConfigMap

--- a/templates/designateapi/config/designate.conf
+++ b/templates/designateapi/config/designate.conf
@@ -71,7 +71,7 @@ stats_update_threads=4
 
 [keystone_authtoken]
 www_authenticate_uri={{ .KeystonePublicURL }}
-auth_url={{ .KeystonePublicURL }}
+auth_url={{ .KeystoneInternalURL }}
 username={{ .ServiceUser }}
 # password=FIXMEpw3
 project_name=service
@@ -81,9 +81,10 @@ auth_type=password
 # memcache_use_advanced_pool=True
 # memcached_servers=FIXMEhost1:11211
 # region_name=regionOne
-# interface=internal
+interface=internal
 
 cafile = /opt/stack/data/ca-bundle.pem
 
 [keystone]
+valid_interfaces=internal
 region_name = RegionOne

--- a/templates/designateapi/config/designate.conf
+++ b/templates/designateapi/config/designate.conf
@@ -83,8 +83,6 @@ auth_type=password
 # region_name=regionOne
 interface=internal
 
-cafile = /opt/stack/data/ca-bundle.pem
-
 [keystone]
 valid_interfaces=internal
 #region_name = regionOne

--- a/templates/designateapi/config/designate.conf
+++ b/templates/designateapi/config/designate.conf
@@ -87,4 +87,4 @@ cafile = /opt/stack/data/ca-bundle.pem
 
 [keystone]
 valid_interfaces=internal
-region_name = RegionOne
+#region_name = regionOne


### PR DESCRIPTION
Internal endpoint is meant for interaction between services. This ensures designate uses internal endpoints when it sends requests to the other services.