### PR TITLE
Simplify pattern to exclude bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,8 @@
 *.dll
 *.so
 *.dylib
-bin
+/bin
 testbin/*
-!/templates/designateapi/bin
 
 # Test binary, build with `go test -c`
 *.test


### PR DESCRIPTION
We can exclude the top-directory instead of using the pattern which can match subdirectories.

Signed-off-by: Takashi Kajinami <tkajinam@redhat.com>