### PR TITLE
Drop redundant quota_* options

### DIFF
--- a/templates/designateapi/config/designate.conf
+++ b/templates/designateapi/config/designate.conf
@@ -9,11 +9,6 @@ logging_exception_prefix = ERROR %(name)s %(instance)s
 logging_default_format_string = %(color)s%(levelname)s %(name)s [-%(color)s] %(instance)s%(color)s%(message)s
 logging_context_format_string = %(color)s%(levelname)s %(name)s [%(global_request_id)s %(request_id)s %(project_name)s %(user_name)s%(color)s] %(instance)s%(color)s%(message)s
 logging_debug_format_suffix = {{(pid=%(process)d) %(funcName)s %(pathname)s:%(lineno)d}}
-quota_api_export_size = 1000
-quota_recordset_records = 20
-quota_zone_records = 500
-quota_zone_recordsets = 500
-quota_zones = 10
 root-helper = sudo
 state_path = /opt/stack/data/designate
 debug = True


### PR DESCRIPTION
The current settings define the value exactly same as the service defaults, thus can be removed. This allows us to reduce number of parameters we have to maintain.