### PR TITLE
Return error in ConfigMap creation

### DIFF
--- a/controllers/designateapi_controller.go
+++ b/controllers/designateapi_controller.go
@@ -641,10 +641,8 @@ func (r *DesignateAPIReconciler) reconcileNormal(ctx context.Context, instance *
 	return ctrl.Result{}, nil
 }
 
-//
 // generateServiceConfigMaps - create create configmaps which hold scripts and service configuration
 // TODO add DefaultConfigOverwrite
-//
 func (r *DesignateAPIReconciler) generateServiceConfigMaps(
 	ctx context.Context,
 	instance *designatev1.DesignateAPI,
@@ -707,20 +705,13 @@ func (r *DesignateAPIReconciler) generateServiceConfigMaps(
 			Labels:        cmLabels,
 		},
 	}
-	err = configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
-	if err != nil {
-		return nil
-	}
-
-	return nil
+	return configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
 }
 
-//
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart
 // if any of the input resources change, like configs, passwords, ...
 //
 // returns the hash, whether the hash changed (as a bool) and any error
-//
 func (r *DesignateAPIReconciler) createHashOfInputHashes(
 	ctx context.Context,
 	instance *designatev1.DesignateAPI,


### PR DESCRIPTION
The current logic ignores the error but it should be returned so that the error can be detected in the reconciler.