### PR TITLE
Use constant to define restart policy

### DIFF
--- a/pkg/designate/dbsync.go
+++ b/pkg/designate/dbsync.go
@@ -60,7 +60,7 @@ func DbSyncJob(
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy:      "OnFailure",
+					RestartPolicy:      corev1.RestartPolicyOnFailure,
 					ServiceAccountName: ServiceAccount,
 					Containers: []corev1.Container{
 						{


### PR DESCRIPTION
... instead hard-coding the string in our own logic.