### PR TITLE
Replace TripleO images by TCIB images

### DIFF
--- a/config/samples/designate_v1beta1_designateapi.yaml
+++ b/config/samples/designate_v1beta1_designateapi.yaml
@@ -7,7 +7,7 @@ spec:
   databaseInstance: openstack
   databaseUser: designate
   serviceUser: designate
-  containerImage: quay.io/tripleowallabycentos9/openstack-designate-api:current-tripleo
+  containerImage: quay.io/podified-antelope-centos9/openstack-designate-api:current-podified
   replicas: 1
   secret: osp-secret
   debug:


### PR DESCRIPTION
We imported container build tools from TripleO as TCIB[1]. Now we are retiring TripleO and should complete the migration.

[1] https://github.com/openstack-k8s-operators/tcib