### PR TITLE
Remove unused constant for admin endpoint

### DIFF
--- a/pkg/designate/const.go
+++ b/pkg/designate/const.go
@@ -23,8 +23,6 @@ const (
 	// DatabaseName -
 	DatabaseName = "designate"
 
-	// DesignateAdminPort -
-	DesignateAdminPort int32 = 9001
 	// DesignatePublicPort -
 	DesignatePublicPort int32 = 9001
 	// DesignateInternalPort -


### PR DESCRIPTION
This constant is no longer used since we removed admin endpoints.