### PR TITLE
Remove endpoint url and keystone service id from status

### DIFF
--- a/api/bases/designate.openstack.org_designateapis.yaml
+++ b/api/bases/designate.openstack.org_designateapis.yaml
@@ -206,13 +206,6 @@ spec:
           status:
             description: DesignateAPIStatus defines the observed state of DesignateAPI
             properties:
-              apiEndpoint:
-                additionalProperties:
-                  additionalProperties:
-                    type: string
-                  type: object
-                description: API endpoint
-                type: object
               conditions:
                 description: Conditions
                 items:
@@ -272,11 +265,6 @@ spec:
                 description: ReadyCount of designate API instances
                 format: int32
                 type: integer
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                description: ServiceIDs - the ID of the registered service in keystone
-                type: object
             type: object
         type: object
     served: true

--- a/api/bases/designate.openstack.org_designates.yaml
+++ b/api/bases/designate.openstack.org_designates.yaml
@@ -995,13 +995,6 @@ spec:
           status:
             description: DesignateStatus defines the observed state of Designate
             properties:
-              apiEndpoints:
-                additionalProperties:
-                  additionalProperties:
-                    type: string
-                  type: object
-                description: API endpoints
-                type: object
               conditions:
                 description: Conditions
                 items:
@@ -1072,11 +1065,6 @@ spec:
                 additionalProperties:
                   type: string
                 description: Map of hashes to track e.g. job status
-                type: object
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                description: ServiceIDs
                 type: object
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL

--- a/api/v1beta1/designate_types.go
+++ b/api/v1beta1/designate_types.go
@@ -141,12 +141,6 @@ type DesignateStatus struct {
 	// TransportURLSecret - Secret containing RabbitMQ transportURL
 	TransportURLSecret string `json:"transportURLSecret,omitempty"`
 
-	// API endpoints
-	APIEndpoints map[string]map[string]string `json:"apiEndpoints,omitempty"`
-
-	// ServiceIDs
-	ServiceIDs map[string]string `json:"serviceIDs,omitempty"`
-
 	// ReadyCount of Designate API instance
 	DesignateAPIReadyCount int32 `json:"designateAPIReadyCount,omitempty"`
 

--- a/api/v1beta1/designateapi_types.go
+++ b/api/v1beta1/designateapi_types.go
@@ -58,17 +58,11 @@ type DesignateAPIStatus struct {
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
 
-	// API endpoint
-	APIEndpoints map[string]map[string]string `json:"apiEndpoint,omitempty"`
-
 	// Conditions
 	Conditions condition.Conditions `json:"conditions,omitempty" optional:"true"`
 
 	// ReadyCount of designate API instances
 	ReadyCount int32 `json:"readyCount,omitempty"`
-
-	// ServiceIDs - the ID of the registered service in keystone
-	ServiceIDs map[string]string `json:"serviceIDs,omitempty"`
 
 	// NetworkAttachments status of the deployment pods
 	NetworkAttachments map[string][]string `json:"networkAttachments,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -140,35 +140,11 @@ func (in *DesignateAPIStatus) DeepCopyInto(out *DesignateAPIStatus) {
 			(*out)[key] = val
 		}
 	}
-	if in.APIEndpoints != nil {
-		in, out := &in.APIEndpoints, &out.APIEndpoints
-		*out = make(map[string]map[string]string, len(*in))
-		for key, val := range *in {
-			var outVal map[string]string
-			if val == nil {
-				(*out)[key] = nil
-			} else {
-				in, out := &val, &outVal
-				*out = make(map[string]string, len(*in))
-				for key, val := range *in {
-					(*out)[key] = val
-				}
-			}
-			(*out)[key] = outVal
-		}
-	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make(condition.Conditions, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
-	if in.ServiceIDs != nil {
-		in, out := &in.ServiceIDs, &out.ServiceIDs
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
 		}
 	}
 	if in.NetworkAttachments != nil {
@@ -799,30 +775,6 @@ func (in *DesignateStatus) DeepCopyInto(out *DesignateStatus) {
 		*out = make(condition.Conditions, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
-		}
-	}
-	if in.APIEndpoints != nil {
-		in, out := &in.APIEndpoints, &out.APIEndpoints
-		*out = make(map[string]map[string]string, len(*in))
-		for key, val := range *in {
-			var outVal map[string]string
-			if val == nil {
-				(*out)[key] = nil
-			} else {
-				in, out := &val, &outVal
-				*out = make(map[string]string, len(*in))
-				for key, val := range *in {
-					(*out)[key] = val
-				}
-			}
-			(*out)[key] = outVal
-		}
-	}
-	if in.ServiceIDs != nil {
-		in, out := &in.ServiceIDs, &out.ServiceIDs
-		*out = make(map[string]string, len(*in))
-		for key, val := range *in {
-			(*out)[key] = val
 		}
 	}
 }

--- a/config/crd/bases/designate.openstack.org_designateapis.yaml
+++ b/config/crd/bases/designate.openstack.org_designateapis.yaml
@@ -206,13 +206,6 @@ spec:
           status:
             description: DesignateAPIStatus defines the observed state of DesignateAPI
             properties:
-              apiEndpoint:
-                additionalProperties:
-                  additionalProperties:
-                    type: string
-                  type: object
-                description: API endpoint
-                type: object
               conditions:
                 description: Conditions
                 items:
@@ -272,11 +265,6 @@ spec:
                 description: ReadyCount of designate API instances
                 format: int32
                 type: integer
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                description: ServiceIDs - the ID of the registered service in keystone
-                type: object
             type: object
         type: object
     served: true

--- a/config/crd/bases/designate.openstack.org_designates.yaml
+++ b/config/crd/bases/designate.openstack.org_designates.yaml
@@ -995,13 +995,6 @@ spec:
           status:
             description: DesignateStatus defines the observed state of Designate
             properties:
-              apiEndpoints:
-                additionalProperties:
-                  additionalProperties:
-                    type: string
-                  type: object
-                description: API endpoints
-                type: object
               conditions:
                 description: Conditions
                 items:
@@ -1072,11 +1065,6 @@ spec:
                 additionalProperties:
                   type: string
                 description: Map of hashes to track e.g. job status
-                type: object
-              serviceIDs:
-                additionalProperties:
-                  type: string
-                description: ServiceIDs
                 type: object
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL

--- a/controllers/designate_controller.go
+++ b/controllers/designate_controller.go
@@ -202,9 +202,6 @@ func (r *DesignateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if instance.Status.Hash == nil {
 		instance.Status.Hash = map[string]string{}
 	}
-	if instance.Status.APIEndpoints == nil {
-		instance.Status.APIEndpoints = map[string]map[string]string{}
-	}
 
 	// Handle service delete
 	if !instance.DeletionTimestamp.IsZero() {
@@ -636,9 +633,7 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 		r.Log.Info(fmt.Sprintf("Deployment %s successfully reconciled - operation: %s", instance.Name, string(op)))
 	}
 
-	// Mirror DesignateAPI status' APIEndpoints and ReadyCount to this parent CR
-	instance.Status.APIEndpoints = designateAPI.Status.APIEndpoints
-	instance.Status.ServiceIDs = designateAPI.Status.ServiceIDs
+	// Mirror DesignateAPI status' ReadyCount to this parent CR
 	instance.Status.DesignateAPIReadyCount = designateAPI.Status.ReadyCount
 
 	// Mirror DesignateAPI's condition status


### PR DESCRIPTION
These items presented in CR status are not really used. Endpoints can be discovered using Keystone and we have no use case to require service id.