### PR TITLE
Stop using KOLLA_CONFIG_FILE environment

### DIFF
--- a/pkg/designate/dbsync.go
+++ b/pkg/designate/dbsync.go
@@ -36,7 +36,7 @@ func DbSyncJob(
 ) *batchv1.Job {
 	runAsUser := int64(0)
 	initVolumeMounts := getInitVolumeMounts()
-	volumeMounts := getVolumeMounts()
+	volumeMounts := GetServiceVolumeMounts("db-sync")
 	volumes := getVolumes(instance.Name)
 
 	args := []string{"-c"}

--- a/pkg/designate/volumes.go
+++ b/pkg/designate/volumes.go
@@ -87,7 +87,7 @@ func GetInitVolumeMounts() []corev1.VolumeMount {
 
 // GetServiceVolumeMounts - VolumeMounts to get access to the merged
 // configuration
-func GetServiceVolumeMounts() []corev1.VolumeMount {
+func GetServiceVolumeMounts(serviceName string) []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{
 			Name:      scriptVolume,
@@ -98,6 +98,12 @@ func GetServiceVolumeMounts() []corev1.VolumeMount {
 			Name:      mergedConfigVolume,
 			MountPath: "/var/lib/config-data/merged",
 			ReadOnly:  false,
+		},
+		{
+			Name:      mergedConfigVolume,
+			MountPath: "/var/lib/kolla/config_files/config.json",
+			SubPath:   serviceName + "-config.json",
+			ReadyOnly: true,
 		},
 	}
 }
@@ -151,22 +157,6 @@ func getInitVolumeMounts() []corev1.VolumeMount {
 		{
 			Name:      "config-data",
 			MountPath: "/var/lib/config-data/default",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "config-data-merged",
-			MountPath: "/var/lib/config-data/merged",
-			ReadOnly:  false,
-		},
-	}
-}
-
-// getVolumeMounts - general VolumeMounts
-func getVolumeMounts() []corev1.VolumeMount {
-	return []corev1.VolumeMount{
-		{
-			Name:      "scripts",
-			MountPath: "/usr/local/bin/container-scripts",
 			ReadOnly:  true,
 		},
 		{

--- a/pkg/designate/volumes.go
+++ b/pkg/designate/volumes.go
@@ -102,31 +102,6 @@ func GetServiceVolumeMounts() []corev1.VolumeMount {
 	}
 }
 
-// GetOpenstackVolumes - returns the volumes used for the service deployment and for
-// any jobs needs access for the full service configuration
-func GetOpenstackVolumes(serviceConfigConfigMapName string) []corev1.Volume {
-	var configMode int32 = 0640
-	return []corev1.Volume{
-		{
-			Name: configVolume,
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					DefaultMode: &configMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: serviceConfigConfigMapName,
-					},
-				},
-			},
-		},
-		{
-			Name: logVolume,
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
-			},
-		},
-	}
-}
-
 // #############################################################################
 // getVolumes
 func getVolumes(name string) []corev1.Volume {

--- a/pkg/designate/volumes.go
+++ b/pkg/designate/volumes.go
@@ -64,7 +64,7 @@ func GetVolumes(baseConfigMapName string) []corev1.Volume {
 	}
 }
 
-// GetInitVolumeMounts - Nova Control Plane init task VolumeMounts
+// GetInitVolumeMounts - Designate Control Plane init task VolumeMounts
 func GetInitVolumeMounts() []corev1.VolumeMount {
 	return []corev1.VolumeMount{
 		{
@@ -79,28 +79,6 @@ func GetInitVolumeMounts() []corev1.VolumeMount {
 		},
 		{
 			Name:      "config-data-merged",
-			MountPath: "/var/lib/config-data/merged",
-			ReadOnly:  false,
-		},
-	}
-}
-
-// GetAllVolumeMounts - VolumeMounts providing access to both the raw input
-// configuration and the volume of the merged configuration
-func GetAllVolumeMounts() []corev1.VolumeMount {
-	return []corev1.VolumeMount{
-		{
-			Name:      scriptVolume,
-			MountPath: "/usr/local/bin/container-scripts",
-			ReadOnly:  true,
-		},
-		{
-			Name:      configVolume,
-			MountPath: "/var/lib/config-data/default",
-			ReadOnly:  true,
-		},
-		{
-			Name:      mergedConfigVolume,
 			MountPath: "/var/lib/config-data/merged",
 			ReadOnly:  false,
 		},

--- a/pkg/designate/volumes.go
+++ b/pkg/designate/volumes.go
@@ -102,22 +102,6 @@ func GetServiceVolumeMounts() []corev1.VolumeMount {
 	}
 }
 
-// GetOpenstackVolumeMounts - VolumeMounts use to inject config and scripts
-func GetOpenstackVolumeMounts() []corev1.VolumeMount {
-	return []corev1.VolumeMount{
-		{
-			Name:      configVolume,
-			MountPath: "/var/lib/openstack/config",
-			ReadOnly:  false,
-		},
-		{
-			Name:      logVolume,
-			MountPath: "/var/log/ndesignate",
-			ReadOnly:  false,
-		},
-	}
-}
-
 // GetOpenstackVolumes - returns the volumes used for the service deployment and for
 // any jobs needs access for the full service configuration
 func GetOpenstackVolumes(serviceConfigConfigMapName string) []corev1.Volume {

--- a/pkg/designateapi/deployment.go
+++ b/pkg/designateapi/deployment.go
@@ -116,7 +116,7 @@ func Deployment(
 								RunAsUser: &runAsUser,
 							},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: designate.GetServiceVolumeMounts(),
+							VolumeMounts: designate.GetServiceVolumeMounts("designate-api"),
 							Resources:    instance.Spec.Resources,
 							//ReadinessProbe: readinessProbe,
 							//LivenessProbe:  livenessProbe,

--- a/pkg/designateapi/deployment.go
+++ b/pkg/designateapi/deployment.go
@@ -101,6 +101,9 @@ func Deployment(
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: instance.Spec.ServiceAccount,
+					Volumes: designate.GetVolumes(
+						designate.GetOwningDesignateName(instance),
+					),
 					Containers: []corev1.Container{
 						{
 							Name: designate.ServiceName + "-api",
@@ -124,8 +127,6 @@ func Deployment(
 			},
 		},
 	}
-	deployment.Spec.Template.Spec.Volumes = designate.GetVolumes(
-		designate.GetOwningDesignateName(instance))
 
 	// If possible two pods of the same service should not
 	// run on the same worker node. If this is not possible

--- a/pkg/designateapi/deployment.go
+++ b/pkg/designateapi/deployment.go
@@ -104,9 +104,6 @@ func Deployment(
 					Containers: []corev1.Container{
 						{
 							Name: designate.ServiceName + "-api",
-							//Command: []string{
-							//"/bin/sleep", "600000",
-							//},
 							Command: []string{
 								"/bin/bash",
 							},
@@ -116,7 +113,7 @@ func Deployment(
 								RunAsUser: &runAsUser,
 							},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: designate.GetAllVolumeMounts(),
+							VolumeMounts: designate.GetServiceVolumeMounts(),
 							Resources:    instance.Spec.Resources,
 							//ReadinessProbe: readinessProbe,
 							//LivenessProbe:  livenessProbe,

--- a/pkg/designatecentral/deployment.go
+++ b/pkg/designatecentral/deployment.go
@@ -60,7 +60,6 @@ func Deployment(
 	// 	InitialDelaySeconds: 5,
 	// }
 	args := []string{"-c"}
-	// var probeCommand []string
 	if instance.Spec.Debug.Service {
 		args = append(args, common.DebugCommand)
 		// livenessProbe.Exec = &corev1.ExecAction{
@@ -69,31 +68,18 @@ func Deployment(
 		// 	},
 		// }
 		// startupProbe.Exec = livenessProbe.Exec
-		// probeCommand = []string{
-		// 	"/bin/sleep", "infinity",
-		// }
 	} else {
 		args = append(args, ServiceCommand)
 		// livenessProbe.HTTPGet = &corev1.HTTPGetAction{
 		// 	Port: intstr.FromInt(8080),
 		// }
 		// startupProbe.HTTPGet = livenessProbe.HTTPGet
-		// // Probe doesn't run kolla_set_configs because it uses the 'designate' uid
-		// // and gid and doesn't have permissions to make files be owned by root,
-		// // so designate.conf is in its original location
-		// probeCommand = []string{
-		// 	"/usr/local/bin/container-scripts/healthcheck.py",
-		// 	"scheduler",
-		// 	"/var/lib/config-data/merged/designate.conf",
-		// }
 	}
 
 	envVars := map[string]env.Setter{}
 	envVars["KOLLA_CONFIG_FILE"] = env.SetValue(KollaConfig)
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
-
-	volumeMounts := designate.GetAllVolumeMounts()
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -119,9 +105,6 @@ func Deployment(
 					Containers: []corev1.Container{
 						{
 							Name: designate.ServiceName + "-central",
-							// Command: []string{
-							// 	"/bin/sleep", "60000",
-							// },
 							Command: []string{
 								"/bin/bash",
 							},
@@ -131,21 +114,11 @@ func Deployment(
 								RunAsUser: &rootUser,
 							},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: volumeMounts,
+							VolumeMounts: designate.GetServiceVolumeMounts()
 							Resources:    instance.Spec.Resources,
 							// StartupProbe:  startupProbe,
 							// LivenessProbe: livenessProbe,
 						},
-						// {
-						// 	Name:    "probe",
-						// 	Command: probeCommand,
-						// 	Image:   instance.Spec.ContainerImage,
-						// 	SecurityContext: &corev1.SecurityContext{
-						// 		RunAsUser:  &designateUser,
-						// 		RunAsGroup: &designateGroup,
-						// 	},
-						// 	VolumeMounts: volumeMounts,
-						// },
 					},
 					NodeSelector: instance.Spec.NodeSelector,
 				},
@@ -178,7 +151,7 @@ func Deployment(
 		TransportURLSecret:   instance.Spec.TransportURLSecret,
 		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
-		VolumeMounts:         designate.GetAllVolumeMounts(),
+		VolumeMounts:         designate.GetInitVolumeMounts(),
 		Debug:                instance.Spec.Debug.InitContainer,
 	}
 	deployment.Spec.Template.Spec.InitContainers = designate.InitContainer(initContainerDetails)

--- a/pkg/designatecentral/deployment.go
+++ b/pkg/designatecentral/deployment.go
@@ -99,8 +99,8 @@ func Deployment(
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes: designate.GetOpenstackVolumes(
-						designate.GetServiceConfigConfigMapName(instance.Name),
+					Volumes: designate.GetVolumes(
+						designate.GetOwningDesignateName(instance),
 					),
 					Containers: []corev1.Container{
 						{
@@ -114,7 +114,7 @@ func Deployment(
 								RunAsUser: &rootUser,
 							},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: designate.GetServiceVolumeMounts()
+							VolumeMounts: designate.GetServiceVolumeMounts(),
 							Resources:    instance.Spec.Resources,
 							// StartupProbe:  startupProbe,
 							// LivenessProbe: livenessProbe,
@@ -125,8 +125,6 @@ func Deployment(
 			},
 		},
 	}
-	deployment.Spec.Template.Spec.Volumes = designate.GetVolumes(
-		designate.GetOwningDesignateName(instance))
 
 	// If possible two pods of the same service should not
 	// run on the same worker node. If this is not possible

--- a/pkg/designatemdns/deployment.go
+++ b/pkg/designatemdns/deployment.go
@@ -99,8 +99,8 @@ func Deployment(
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes: designate.GetOpenstackVolumes(
-						designate.GetServiceConfigConfigMapName(instance.Name),
+					Volumes: designate.GetVolumes(
+						designate.GetOwningDesignateName(instance),
 					),
 					Containers: []corev1.Container{
 						{
@@ -125,8 +125,6 @@ func Deployment(
 			},
 		},
 	}
-	deployment.Spec.Template.Spec.Volumes = designate.GetVolumes(
-		designate.GetOwningDesignateName(instance))
 
 	// If possible two pods of the same service should not
 	// run on the same worker node. If this is not possible

--- a/pkg/designateproducer/deployment.go
+++ b/pkg/designateproducer/deployment.go
@@ -99,8 +99,8 @@ func Deployment(
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes: designate.GetOpenstackVolumes(
-						designate.GetServiceConfigConfigMapName(instance.Name),
+					Volumes: designate.GetVolumes(
+						designate.GetOwningDesignateName(instance),
 					),
 					Containers: []corev1.Container{
 						{
@@ -125,8 +125,6 @@ func Deployment(
 			},
 		},
 	}
-	deployment.Spec.Template.Spec.Volumes = designate.GetVolumes(
-		designate.GetOwningDesignateName(instance))
 
 	// If possible two pods of the same service should not
 	// run on the same worker node. If this is not possible

--- a/pkg/designateproducer/deployment.go
+++ b/pkg/designateproducer/deployment.go
@@ -60,7 +60,6 @@ func Deployment(
 	// 	InitialDelaySeconds: 5,
 	// }
 	args := []string{"-c"}
-	// var probeCommand []string
 	if instance.Spec.Debug.Service {
 		args = append(args, common.DebugCommand)
 		// livenessProbe.Exec = &corev1.ExecAction{
@@ -69,31 +68,18 @@ func Deployment(
 		// 	},
 		// }
 		// startupProbe.Exec = livenessProbe.Exec
-		// probeCommand = []string{
-		// 	"/bin/sleep", "infinity",
-		// }
 	} else {
 		args = append(args, ServiceCommand)
 		// livenessProbe.HTTPGet = &corev1.HTTPGetAction{
 		// 	Port: intstr.FromInt(8080),
 		// }
 		// startupProbe.HTTPGet = livenessProbe.HTTPGet
-		// // Probe doesn't run kolla_set_configs because it uses the 'designate' uid
-		// // and gid and doesn't have permissions to make files be owned by root,
-		// // so designate.conf is in its original location
-		// probeCommand = []string{
-		// 	"/usr/local/bin/container-scripts/healthcheck.py",
-		// 	"scheduler",
-		// 	"/var/lib/config-data/merged/designate.conf",
-		// }
 	}
 
 	envVars := map[string]env.Setter{}
 	envVars["KOLLA_CONFIG_FILE"] = env.SetValue(KollaConfig)
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
-
-	volumeMounts := designate.GetAllVolumeMounts()
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -119,9 +105,6 @@ func Deployment(
 					Containers: []corev1.Container{
 						{
 							Name: designate.ServiceName + "-producer",
-							// Command: []string{
-							// 	"/bin/sleep", "60000",
-							// },
 							Command: []string{
 								"/bin/bash",
 							},
@@ -131,21 +114,11 @@ func Deployment(
 								RunAsUser: &rootAsUser,
 							},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: volumeMounts,
+							VolumeMounts: designate.GetServiceVolumeMounts(),
 							Resources:    instance.Spec.Resources,
 							// StartupProbe:  startupProbe,
 							// LivenessProbe: livenessProbe,
 						},
-						// {
-						// 	Name:    "probe",
-						// 	Command: probeCommand,
-						// 	Image:   instance.Spec.ContainerImage,
-						// 	SecurityContext: &corev1.SecurityContext{
-						// 		RunAsUser:  &designateUser,
-						// 		RunAsGroup: &designateGroup,
-						// 	},
-						// 	VolumeMounts: volumeMounts,
-						// },
 					},
 					NodeSelector: instance.Spec.NodeSelector,
 				},
@@ -178,7 +151,7 @@ func Deployment(
 		TransportURLSecret:   instance.Spec.TransportURLSecret,
 		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
-		VolumeMounts:         designate.GetAllVolumeMounts(),
+		VolumeMounts:         designate.GetInitVolumeMounts(),
 		Debug:                instance.Spec.Debug.InitContainer,
 	}
 	deployment.Spec.Template.Spec.InitContainers = designate.InitContainer(initContainerDetails)

--- a/pkg/designateworker/deployment.go
+++ b/pkg/designateworker/deployment.go
@@ -102,8 +102,8 @@ func Deployment(
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: instance.Spec.ServiceAccount,
-					Volumes: designate.GetOpenstackVolumes(
-						designate.GetServiceConfigConfigMapName(instance.Name),
+					Volumes: designate.GetVolumes(
+						designate.GetOwningDesignateName(instance),
 					),
 					Containers: []corev1.Container{
 						{
@@ -128,8 +128,6 @@ func Deployment(
 			},
 		},
 	}
-	deployment.Spec.Template.Spec.Volumes = designate.GetVolumes(
-		designate.GetOwningDesignateName(instance))
 
 	// If possible two pods of the same service should not
 	// run on the same worker node. If this is not possible

--- a/pkg/designateworker/deployment.go
+++ b/pkg/designateworker/deployment.go
@@ -60,7 +60,6 @@ func Deployment(
 	// 	InitialDelaySeconds: 5,
 	// }
 	args := []string{"-c"}
-	// var probeCommand []string
 	if instance.Spec.Debug.Service {
 		args = append(args, common.DebugCommand)
 		// livenessProbe.Exec = &corev1.ExecAction{
@@ -69,9 +68,6 @@ func Deployment(
 		// 	},
 		// }
 		// startupProbe.Exec = livenessProbe.Exec
-		// probeCommand = []string{
-		// 	"/bin/sleep", "infinity",
-		// }
 	} else {
 		args = append(args, ServiceCommand)
 		// livenessProbe.HTTPGet = &corev1.HTTPGetAction{
@@ -81,19 +77,12 @@ func Deployment(
 		// // Probe doesn't run kolla_set_configs because it uses the 'designate' uid
 		// // and gid and doesn't have permissions to make files be owned by root,
 		// // so designate.conf is in its original location
-		// probeCommand = []string{
-		// 	"/usr/local/bin/container-scripts/healthcheck.py",
-		// 	"scheduler",
-		// 	"/var/lib/config-data/merged/designate.conf",
-		// }
 	}
 
 	envVars := map[string]env.Setter{}
 	envVars["KOLLA_CONFIG_FILE"] = env.SetValue(KollaConfig)
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
-
-	volumeMounts := designate.GetAllVolumeMounts()
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -119,9 +108,6 @@ func Deployment(
 					Containers: []corev1.Container{
 						{
 							Name: designate.ServiceName + "-worker",
-							// Command: []string{
-							// 	"/bin/sleep", "60000",
-							// },
 							Command: []string{
 								"/bin/bash",
 							},
@@ -131,21 +117,11 @@ func Deployment(
 								RunAsUser: &rootUser,
 							},
 							Env:          env.MergeEnvs([]corev1.EnvVar{}, envVars),
-							VolumeMounts: volumeMounts,
+							VolumeMounts: designate.GetServiceVolumeMounts(),
 							Resources:    instance.Spec.Resources,
 							// StartupProbe:  startupProbe,
 							// LivenessProbe: livenessProbe,
 						},
-						// {
-						// 	Name:    "probe",
-						// 	Command: probeCommand,
-						// 	Image:   instance.Spec.ContainerImage,
-						// 	SecurityContext: &corev1.SecurityContext{
-						// 		RunAsUser:  &designateUser,
-						// 		RunAsGroup: &designateGroup,
-						// 	},
-						// 	VolumeMounts: volumeMounts,
-						// },
 					},
 					NodeSelector: instance.Spec.NodeSelector,
 				},
@@ -178,7 +154,7 @@ func Deployment(
 		TransportURLSecret:   instance.Spec.TransportURLSecret,
 		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
-		VolumeMounts:         designate.GetAllVolumeMounts(),
+		VolumeMounts:         designate.GetInitVolumeMounts(),
 		Debug:                instance.Spec.Debug.InitContainer,
 	}
 	deployment.Spec.Template.Spec.InitContainers = designate.InitContainer(initContainerDetails)


### PR DESCRIPTION
and refactors how volumes and volume mounts are managed.

I also noticed this operator currently lacks the logic to present customServiceConfig in sub CR layer but that is not covered by this change and should be addressed separately.