### PR TITLE
Remove KOLLA_CONFIG_FILE environment variable

### DIFF
--- a/pkg/designate/const.go
+++ b/pkg/designate/const.go
@@ -27,7 +27,4 @@ const (
 	DesignatePublicPort int32 = 9001
 	// DesignateInternalPort -
 	DesignateInternalPort int32 = 9001
-
-	// KollaDbSyncConfig -
-	KollaDbSyncConfig = "/var/lib/config-data/merged/db-sync-config.json"
 )

--- a/pkg/designate/dbsync.go
+++ b/pkg/designate/dbsync.go
@@ -47,7 +47,6 @@ func DbSyncJob(
 	}
 
 	envVars := map[string]env.Setter{}
-	envVars["KOLLA_CONFIG_FILE"] = env.SetValue(KollaDbSyncConfig)
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["KOLLA_BOOTSTRAP"] = env.SetValue("TRUE")
 

--- a/pkg/designateapi/const.go
+++ b/pkg/designateapi/const.go
@@ -16,9 +16,6 @@ limitations under the License.
 package designateapi
 
 const (
-	// KollaConfig -
-	KollaConfig = "/var/lib/config-data/merged/designate-api-config.json"
-
 	// Component -
 	Component = "designate-api"
 )

--- a/pkg/designateapi/deployment.go
+++ b/pkg/designateapi/deployment.go
@@ -79,7 +79,6 @@ func Deployment(
 	}
 
 	envVars := map[string]env.Setter{}
-	envVars["KOLLA_CONFIG_FILE"] = env.SetValue(KollaConfig)
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
 

--- a/pkg/designatecentral/const.go
+++ b/pkg/designatecentral/const.go
@@ -16,9 +16,6 @@ limitations under the License.
 package designatecentral
 
 const (
-	// KollaConfig -
-	KollaConfig = "/var/lib/config-data/merged/designate-central-config.json"
-
 	// Component -
 	Component = "designate-central"
 )

--- a/pkg/designatecentral/deployment.go
+++ b/pkg/designatecentral/deployment.go
@@ -77,7 +77,6 @@ func Deployment(
 	}
 
 	envVars := map[string]env.Setter{}
-	envVars["KOLLA_CONFIG_FILE"] = env.SetValue(KollaConfig)
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
 

--- a/pkg/designatemdns/const.go
+++ b/pkg/designatemdns/const.go
@@ -16,9 +16,6 @@ limitations under the License.
 package designatemdns
 
 const (
-	// KollaConfig -
-	KollaConfig = "/var/lib/config-data/merged/designate-mdns-config.json"
-
 	// Component -
 	Component = "designate-mdns"
 )

--- a/pkg/designatemdns/deployment.go
+++ b/pkg/designatemdns/deployment.go
@@ -77,7 +77,6 @@ func Deployment(
 	}
 
 	envVars := map[string]env.Setter{}
-	envVars["KOLLA_CONFIG_FILE"] = env.SetValue(KollaConfig)
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
 

--- a/pkg/designateproducer/const.go
+++ b/pkg/designateproducer/const.go
@@ -16,9 +16,6 @@ limitations under the License.
 package designateproducer
 
 const (
-	// KollaConfig -
-	KollaConfig = "/var/lib/config-data/merged/designate-producer-config.json"
-
 	// Component -
 	Component = "designate-producer"
 )

--- a/pkg/designateproducer/deployment.go
+++ b/pkg/designateproducer/deployment.go
@@ -77,7 +77,6 @@ func Deployment(
 	}
 
 	envVars := map[string]env.Setter{}
-	envVars["KOLLA_CONFIG_FILE"] = env.SetValue(KollaConfig)
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
 

--- a/pkg/designateworker/const.go
+++ b/pkg/designateworker/const.go
@@ -16,9 +16,6 @@ limitations under the License.
 package designateworker
 
 const (
-	// KollaConfig -
-	KollaConfig = "/var/lib/config-data/merged/designate-worker-config.json"
-
 	// Component -
 	Component = "designate-worker"
 )

--- a/pkg/designateworker/deployment.go
+++ b/pkg/designateworker/deployment.go
@@ -80,7 +80,6 @@ func Deployment(
 	}
 
 	envVars := map[string]env.Setter{}
-	envVars["KOLLA_CONFIG_FILE"] = env.SetValue(KollaConfig)
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
 


### PR DESCRIPTION
The previous attempt added the bind mount to expose the config file to the default path but it did not remove the environment variable actually from pods.