### PR TITLE
Fix transposed characters for designate

### DIFF
--- a/api/bases/designate.openstack.org_designateapis.yaml
+++ b/api/bases/designate.openstack.org_designateapis.yaml
@@ -55,13 +55,13 @@ spec:
                 type: string
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:mdns'']'
                 type: string
               backendWorkerServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:worker'']'
                 type: string

--- a/api/bases/designate.openstack.org_designatebackendbind9s.yaml
+++ b/api/bases/designate.openstack.org_designatebackendbind9s.yaml
@@ -51,13 +51,13 @@ spec:
                 type: string
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:mdns'']'
                 type: string
               backendWorkerServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:worker'']'
                 type: string

--- a/api/bases/designate.openstack.org_designatecentrals.yaml
+++ b/api/bases/designate.openstack.org_designatecentrals.yaml
@@ -55,13 +55,13 @@ spec:
                 type: string
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:mdns'']'
                 type: string
               backendWorkerServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:worker'']'
                 type: string

--- a/api/bases/designate.openstack.org_designatemdnses.yaml
+++ b/api/bases/designate.openstack.org_designatemdnses.yaml
@@ -55,13 +55,13 @@ spec:
                 type: string
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:mdns'']'
                 type: string
               backendWorkerServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:worker'']'
                 type: string

--- a/api/bases/designate.openstack.org_designateproducers.yaml
+++ b/api/bases/designate.openstack.org_designateproducers.yaml
@@ -55,13 +55,13 @@ spec:
                 type: string
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:mdns'']'
                 type: string
               backendWorkerServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:worker'']'
                 type: string

--- a/api/bases/designate.openstack.org_designates.yaml
+++ b/api/bases/designate.openstack.org_designates.yaml
@@ -51,13 +51,13 @@ spec:
                 type: string
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:mdns'']'
                 type: string
               backendWorkerServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:worker'']'
                 type: string
@@ -114,13 +114,13 @@ spec:
                     type: string
                   backendMdnsServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:mdns'']'
                     type: string
                   backendWorkerServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:worker'']'
                     type: string
@@ -476,13 +476,13 @@ spec:
                     type: string
                   backendMdnsServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:mdns'']'
                     type: string
                   backendWorkerServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:worker'']'
                     type: string
@@ -656,13 +656,13 @@ spec:
                     type: string
                   backendMdnsServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:mdns'']'
                     type: string
                   backendWorkerServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:worker'']'
                     type: string
@@ -836,13 +836,13 @@ spec:
                     type: string
                   backendMdnsServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:mdns'']'
                     type: string
                   backendWorkerServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:worker'']'
                     type: string
@@ -1016,13 +1016,13 @@ spec:
                     type: string
                   backendMdnsServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:mdns'']'
                     type: string
                   backendWorkerServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:worker'']'
                     type: string

--- a/api/bases/designate.openstack.org_designateworkers.yaml
+++ b/api/bases/designate.openstack.org_designateworkers.yaml
@@ -51,13 +51,13 @@ spec:
                 type: string
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:mdns'']'
                 type: string
               backendWorkerServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:worker'']'
                 type: string

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -64,14 +64,14 @@ type DesignateTemplate struct {
 	BackendType string `json:"None"`
 
 	// +kubebuilder:validation:Optional
-	// BackendTypeProtocol - Defines the backend protocol to be used between the desigante-worker &
-	// desigante_mdns to/from the DNS server. Acceptable values are: "UDP", "TCP"
+	// BackendTypeProtocol - Defines the backend protocol to be used between the designate-worker &
+	// designate_mdns to/from the DNS server. Acceptable values are: "UDP", "TCP"
 	// Please Note: this MUST match what is in the /etc/designate.conf ['service:worker']
 	BackendWorkerServerProtocol string `json:"backendWorkerServerProtocol"`
 
 	// +kubebuilder:validation:Optional
-	// BackendTypeProtocol - Defines the backend protocol to be used between the desigante-worker &
-	// desigante_mdns to/from the DNS server. Acceptable values are: "UDP", "TCP"
+	// BackendTypeProtocol - Defines the backend protocol to be used between the designate-worker &
+	// designate_mdns to/from the DNS server. Acceptable values are: "UDP", "TCP"
 	// Please Note: this MUST match what is in the /etc/designate.conf ['service:mdns']
 	BackendMdnsServerProtocol string `json:"backendMdnsServerProtocol"`
 }

--- a/api/v1beta1/designate_types.go
+++ b/api/v1beta1/designate_types.go
@@ -80,14 +80,14 @@ type DesignateSpec struct {
 	BackendType string `json:"None"`
 
 	// +kubebuilder:validation:Optional
-	// BackendTypeProtocol - Defines the backend protocol to be used between the desigante-worker &
-	// desigante_mdns to/from the DNS server. Acceptable values are: "UDP", "TCP"
+	// BackendTypeProtocol - Defines the backend protocol to be used between the designate-worker &
+	// designate_mdns to/from the DNS server. Acceptable values are: "UDP", "TCP"
 	// Please Note: this MUST match what is in the /etc/designate.conf ['service:worker']
 	BackendWorkerServerProtocol string `json:"backendWorkerServerProtocol"`
 
 	// +kubebuilder:validation:Optional
-	// BackendTypeProtocol - Defines the backend protocol to be used between the desigante-worker &
-	// desigante_mdns to/from the DNS server. Acceptable values are: "UDP", "TCP"
+	// BackendTypeProtocol - Defines the backend protocol to be used between the designate-worker &
+	// designate_mdns to/from the DNS server. Acceptable values are: "UDP", "TCP"
 	// Please Note: this MUST match what is in the /etc/designate.conf ['service:mdns']
 	BackendMdnsServerProtocol string `json:"backendMdnsServerProtocol"`
 

--- a/config/crd/bases/designate.openstack.org_designateapis.yaml
+++ b/config/crd/bases/designate.openstack.org_designateapis.yaml
@@ -55,13 +55,13 @@ spec:
                 type: string
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:mdns'']'
                 type: string
               backendWorkerServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:worker'']'
                 type: string

--- a/config/crd/bases/designate.openstack.org_designatebackendbind9s.yaml
+++ b/config/crd/bases/designate.openstack.org_designatebackendbind9s.yaml
@@ -51,13 +51,13 @@ spec:
                 type: string
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:mdns'']'
                 type: string
               backendWorkerServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:worker'']'
                 type: string

--- a/config/crd/bases/designate.openstack.org_designatecentrals.yaml
+++ b/config/crd/bases/designate.openstack.org_designatecentrals.yaml
@@ -55,13 +55,13 @@ spec:
                 type: string
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:mdns'']'
                 type: string
               backendWorkerServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:worker'']'
                 type: string

--- a/config/crd/bases/designate.openstack.org_designatemdnses.yaml
+++ b/config/crd/bases/designate.openstack.org_designatemdnses.yaml
@@ -55,13 +55,13 @@ spec:
                 type: string
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:mdns'']'
                 type: string
               backendWorkerServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:worker'']'
                 type: string

--- a/config/crd/bases/designate.openstack.org_designateproducers.yaml
+++ b/config/crd/bases/designate.openstack.org_designateproducers.yaml
@@ -55,13 +55,13 @@ spec:
                 type: string
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:mdns'']'
                 type: string
               backendWorkerServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:worker'']'
                 type: string

--- a/config/crd/bases/designate.openstack.org_designates.yaml
+++ b/config/crd/bases/designate.openstack.org_designates.yaml
@@ -51,13 +51,13 @@ spec:
                 type: string
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:mdns'']'
                 type: string
               backendWorkerServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:worker'']'
                 type: string
@@ -114,13 +114,13 @@ spec:
                     type: string
                   backendMdnsServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:mdns'']'
                     type: string
                   backendWorkerServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:worker'']'
                     type: string
@@ -476,13 +476,13 @@ spec:
                     type: string
                   backendMdnsServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:mdns'']'
                     type: string
                   backendWorkerServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:worker'']'
                     type: string
@@ -656,13 +656,13 @@ spec:
                     type: string
                   backendMdnsServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:mdns'']'
                     type: string
                   backendWorkerServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:worker'']'
                     type: string
@@ -836,13 +836,13 @@ spec:
                     type: string
                   backendMdnsServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:mdns'']'
                     type: string
                   backendWorkerServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:worker'']'
                     type: string
@@ -1016,13 +1016,13 @@ spec:
                     type: string
                   backendMdnsServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:mdns'']'
                     type: string
                   backendWorkerServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
-                      to be used between the desigante-worker & desigante_mdns to/from
+                      to be used between the designate-worker & designate_mdns to/from
                       the DNS server. Acceptable values are: "UDP", "TCP" Please Note:
                       this MUST match what is in the /etc/designate.conf [''service:worker'']'
                     type: string

--- a/config/crd/bases/designate.openstack.org_designateworkers.yaml
+++ b/config/crd/bases/designate.openstack.org_designateworkers.yaml
@@ -51,13 +51,13 @@ spec:
                 type: string
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:mdns'']'
                 type: string
               backendWorkerServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
-                  be used between the desigante-worker & desigante_mdns to/from the
+                  be used between the designate-worker & designate_mdns to/from the
                   DNS server. Acceptable values are: "UDP", "TCP" Please Note: this
                   MUST match what is in the /etc/designate.conf [''service:worker'']'
                 type: string

--- a/pkg/designatebackendbind9/deployment.go
+++ b/pkg/designatebackendbind9/deployment.go
@@ -38,10 +38,10 @@ const (
 func Deployment(instance *designatev1beta1.DesignateBackendbind9) *appsv1.Deployment {
 	matchls := map[string]string{
 		"app":   "designaatebackendbind9",
-		"cr":    "desigantebac kendbind9-" + instance.Name,
+		"cr":    "designatebackendbind9-" + instance.Name,
 		"owner": "designate-operator",
 	}
-	ls := labels.GetLabels(instance, "desigantebackendbind9", matchls)
+	ls := labels.GetLabels(instance, "designatebackendbind9", matchls)
 
 	// livenessProbe := &corev1.Probe{
 	// 	// TODO might need tuning

--- a/templates/designate/config/rndc.conf
+++ b/templates/designate/config/rndc.conf
@@ -6,6 +6,6 @@ options {
     default-port RNDCPORT;
 };
 
-acl "desigante_workers" {
+acl "designate_workers" {
     IPV4ADDR;
 };


### PR DESCRIPTION
There are a few locations where designate is mispelled that might cause confusion or configuration errors.