### PR TITLE
Use database helpers from mariadb-operator/api

### DIFF
--- a/controllers/designate_controller.go
+++ b/controllers/designate_controller.go
@@ -49,7 +49,6 @@ import (
 	common_rbac "github.com/openstack-k8s-operators/lib-common/modules/common/rbac"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
-	"github.com/openstack-k8s-operators/lib-common/modules/database"
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -283,7 +282,7 @@ func (r *DesignateReconciler) reconcileDelete(ctx context.Context, instance *des
 	r.Log.Info(fmt.Sprintf("Reconciling Service '%s' delete", instance.Name))
 
 	// remove db finalizer first
-	db, err := database.GetDatabaseByName(ctx, helper, instance.Name)
+	db, err := mariadbv1.GetDatabaseByName(ctx, helper, instance.Name)
 	if err != nil && !k8s_errors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
@@ -316,7 +315,7 @@ func (r *DesignateReconciler) reconcileInit(
 	//
 	// create service DB instance
 	//
-	db := database.NewDatabase(
+	db := mariadbv1.NewDatabase(
 		instance.Name,
 		instance.Spec.DatabaseUser,
 		instance.Spec.Secret,

--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,7 @@ require (
 	github.com/openstack-k8s-operators/infra-operator/apis v0.1.1-0.20231001103054-f74a88ed4971
 	github.com/openstack-k8s-operators/keystone-operator/api v0.1.1-0.20231003172225-508b207a4ce1
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.1.1-0.20231003132907-ac381258ad77
-	github.com/openstack-k8s-operators/lib-common/modules/database v0.1.1-0.20231003132907-ac381258ad77
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928152002-65395552e015
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.0
 	k8s.io/api v0.26.9
 	k8s.io/apimachinery v0.26.9
 	k8s.io/client-go v0.26.9

--- a/go.sum
+++ b/go.sum
@@ -240,14 +240,12 @@ github.com/openstack-k8s-operators/keystone-operator/api v0.1.1-0.20231003172225
 github.com/openstack-k8s-operators/keystone-operator/api v0.1.1-0.20231003172225-508b207a4ce1/go.mod h1:5v0ngxNmFp8QsINo2bufx1/COJc0q6jm3FMhP3xIAWE=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.1.1-0.20231003132907-ac381258ad77 h1:M0dEWP7VhzpQjcp5sO39DzQRA7DizsGxRsrHu4NxV5Q=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.1.1-0.20231003132907-ac381258ad77/go.mod h1:Ozg6SxfwOtMkiH553c0XQBWuygZQq4jDQCpR4hZqlxM=
-github.com/openstack-k8s-operators/lib-common/modules/database v0.1.1-0.20231003132907-ac381258ad77 h1:8n5bzghATMNEYibMHfYW/ExiuupqSVkPb8SjYnia62I=
-github.com/openstack-k8s-operators/lib-common/modules/database v0.1.1-0.20231003132907-ac381258ad77/go.mod h1:RroLfB6Wstc+z7JVJY9o+6YPu+wBIzTAAfMpwhv7pDI=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.20231003132907-ac381258ad77 h1:FTGdbIvG/uFpdTQEzwWOaq84nrphHjIJsD19Orm/+00=
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.1.1-0.20231003132907-ac381258ad77/go.mod h1:LOXXvTQCwhOBNd+0FTlgllpa3wqlkI6Vf3Q5QVRVPlw=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.1.1-0.20231003132907-ac381258ad77 h1:Dsh2vC3cPSGIaMOYG0NGMZByKnf9VDsGzVP7jakST3M=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.1.1-0.20231003132907-ac381258ad77/go.mod h1:qkK/2JzIGOzoctfe0sbL+mSelrEmErAND4vuj1qTU/A=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928152002-65395552e015 h1:1G37nuB9C8QPp7tScEpwbR7eQj+2e6l089MNzj5cChk=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.1.1-0.20230928152002-65395552e015/go.mod h1:xhiz5wFdKWwVM7BF/VYon4TT3NuUPXp/Pyn2hWcp0CE=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.0 h1:FB0xB6whYM6W4XIncYo2mPiOJWkFsIOWtCT+UOtvOaQ=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.0/go.mod h1:xhiz5wFdKWwVM7BF/VYon4TT3NuUPXp/Pyn2hWcp0CE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/designate/common.go
+++ b/pkg/designate/common.go
@@ -19,7 +19,7 @@ package designate
 import (
 	"fmt"
 
-	"github.com/openstack-k8s-operators/lib-common/modules/database"
+	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
 )
 
 const (
@@ -67,7 +67,7 @@ const (
 
 // Database -
 type Database struct {
-	Database *database.Database
+	Database *mariadbv1.Database
 	Status   DatabaseStatus
 }
 


### PR DESCRIPTION
The lib-common/modules/database is moved to mariadb-operator/api to remove a circular dependency.