### PR TITLE
DNM: test patch

### DIFF
--- a/main.go
+++ b/main.go
@@ -188,6 +188,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "DesignateBackendbind9")
 		os.Exit(1)
 	}
+	// XXX do not merge this
 
 	// Acquire environmental defaults and initialize operator defaults with them
 	designatev1beta1.SetupDefaults()


### PR DESCRIPTION
deployments are failing in db-sync with internal errors on a PR and there is no readily available info to aide in debugging. This is a test patch to see if that PR is at fault or something has happened to break kuttl deployments.