### PR TITLE
Support disconnected network environments

### DIFF
--- a/.prow_ci.env
+++ b/.prow_ci.env
@@ -1,0 +1,1 @@
+export USE_IMAGE_DIGESTS=true

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+DEFAULT_IMG ?= quay.io/openstack-k8s-operators/designate-operator:latest
+IMG ?= $(DEFAULT_IMG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.25.0
 

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -169,13 +169,13 @@ type DesignateServiceDebug struct {
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize Designate defaults with them
 	designateDefaults := DesignateDefaults{
-		APIContainerImageURL:          util.GetEnvVar("DESIGNATE_API_IMAGE_URL_DEFAULT", DesignateAPIContainerImage),
-		CentralContainerImageURL:      util.GetEnvVar("DESIGNATE_CENTRAL_IMAGE_URL_DEFAULT", DesignateCentralContainerImage),
-		MdnsContainerImageURL:         util.GetEnvVar("DESIGNATE_MDNS_IMAGE_URL_DEFAULT", DesignateMdnsContainerImage),
-		ProducerContainerImageURL:     util.GetEnvVar("DESIGNATE_PRODUCER_IMAGE_URL_DEFAULT", DesignateProducerContainerImage),
-		WorkerContainerImageURL:       util.GetEnvVar("DESIGNATE_WORKER_IMAGE_URL_DEFAULT", DesignateWorkerContainerImage),
-		UnboundContainerImageURL:      util.GetEnvVar("DESIGNATE_UNBOUND_IMAGE_URL_DEFAULT", DesignateUnboundContainerImage),
-		Backendbind9ContainerImageURL: util.GetEnvVar("DESIGNATE_BACKENDBIND9_IMAGE_URL_DEFAULT", DesignateBackendbind9ContainerImage),
+		APIContainerImageURL:          util.GetEnvVar("RELATED_IMAGE_DESIGNATE_API_IMAGE_URL_DEFAULT", DesignateAPIContainerImage),
+		CentralContainerImageURL:      util.GetEnvVar("RELATED_IMAGE_DESIGNATE_CENTRAL_IMAGE_URL_DEFAULT", DesignateCentralContainerImage),
+		MdnsContainerImageURL:         util.GetEnvVar("RELATED_IMAGE_DESIGNATE_MDNS_IMAGE_URL_DEFAULT", DesignateMdnsContainerImage),
+		ProducerContainerImageURL:     util.GetEnvVar("RELATED_IMAGE_DESIGNATE_PRODUCER_IMAGE_URL_DEFAULT", DesignateProducerContainerImage),
+		WorkerContainerImageURL:       util.GetEnvVar("RELATED_IMAGE_DESIGNATE_WORKER_IMAGE_URL_DEFAULT", DesignateWorkerContainerImage),
+		UnboundContainerImageURL:      util.GetEnvVar("RELATED_IMAGE_DESIGNATE_UNBOUND_IMAGE_URL_DEFAULT", DesignateUnboundContainerImage),
+		Backendbind9ContainerImageURL: util.GetEnvVar("RELATED_IMAGE_DESIGNATE_BACKENDBIND9_IMAGE_URL_DEFAULT", DesignateBackendbind9ContainerImage),
 	}
 
 	SetupDesignateDefaults(designateDefaults)

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,17 +11,17 @@ spec:
       containers:
       - name: manager
         env:
-        - name: DESIGNATE_API_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_DESIGNATE_API_IMAGE_URL_DEFAULT
           value: quay.io/tripleowallabycentos9/openstack-designate-api:current-tripleo
-        - name: DESIGNATE_CENTRAL_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_DESIGNATE_CENTRAL_IMAGE_URL_DEFAULT
           value: quay.io/tripleowallabycentos9/openstack-designate-central:current-tripleo
-        - name: DESIGNATE_MDNS_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_DESIGNATE_MDNS_IMAGE_URL_DEFAULT
           value: quay.io/tripleowallabycentos9/openstack-designate-mdns:current-tripleo
-        - name: DESIGNATE_PRODUCER_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_DESIGNATE_PRODUCER_IMAGE_URL_DEFAULT
           value: quay.io/tripleowallabycentos9/openstack-designate-producer:current-tripleo
-        - name: DESIGNATE_WORKER_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_DESIGNATE_WORKER_IMAGE_URL_DEFAULT
           value: quay.io/tripleowallabycentos9/openstack-designate-worker:current-tripleo
-        - name: DESIGNATE_BACKENDBIND9_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_DESIGNATE_BACKENDBIND9_IMAGE_URL_DEFAULT
           value: quay.io/tripleowallabycentos9/openstack-designate-backend-bind9:current-tripleo
-        - name: DESIGNATE_UNBOUND_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_DESIGNATE_UNBOUND_IMAGE_URL_DEFAULT
           value: quay.io/tripleowallabycentos9/openstack-unbound:current-tripleo

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
+  newName: quay.io/openstack-k8s-operators/designate-operator
   newTag: latest

--- a/config/manifests/bases/designate-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/designate-operator.clusterserviceversion.yaml
@@ -4,7 +4,8 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    operatorframework.io/suggested-namespace: openstack
+    features.operators.openshift.io/disconnected: "true"
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
   name: designate-operator.v0.0.0
   namespace: placeholder
 spec:

--- a/config/manifests/bases/designate-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/designate-operator.clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
     capabilities: Basic Install
     features.operators.openshift.io/disconnected: "true"
     operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.operatorframework.io/operator-type: non-standalone
   name: designate-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
This PR adds support for installing the operator in disconnected network environments. To build with image-digests set USE_IMAGE_DIGESTS=true before running make bundle.

For Prow jobs we are enabling this via .prow-ci.env

(NOTE: this currently requires a secure registry)