### PR TITLE
Extend list of approvers to network-approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 approvers:
-  - designate-approvers
+  - network-approvers
   - ci-approvers
   - openstack-approvers
 
 reviewers:
-  - designate-approvers
+  - network-approvers
   - ci-approvers
   - openstack-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,14 +1,17 @@
 # See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
 
 aliases:
-  designate-approvers:
-  - beagles
-  - johnsom
-  - dkehn
   ci-approvers:
   - lewisdenny
   - frenzyfriday
   - viroel
+  network-approvers:
+  - beagles
+  - gthiemonge
+  - johnsom
+  - karelyatin
+  - slawqo
+  - weinimo
   openstack-approvers:
   - abays
   - dprince


### PR DESCRIPTION
This extended list of approvers should make it easier to integrate PRs, and it aligns with the approvers list of octavia-operator, which is similar in it's team structure.