### PR TITLE
Restore Designate LeaderElectionID

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "98809e87.openstack.org",
+		LeaderElectionID:       "f9497e05.openstack.org",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly


### PR DESCRIPTION
The Designate LeaderElectionID was updated [0] by mistake to the same ID as the Octavia operator [1], it creates a race condition when both operators start, they both try to acquire the same resource. Fixing this issue by restoring the previous ID.

[0] https://github.com/openstack-k8s-operators/designate-operator/commit/f8967a4cf183f226992f439cfe926cbf7f928d96#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R83
[1] https://github.com/openstack-k8s-operators/octavia-operator/blob/c143deb4c63f4696e8d613611087aae48613a4db/main.go#L102