### PR TITLE
Update container images

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -25,19 +25,19 @@ const (
 	// Container image fall-back defaults
 
 	// DesignateAPIContainerImage is the fall-back container image for DesignateAPI
-	DesignateAPIContainerImage = "quay.io/tripleowallabycentos9/openstack-designate-api:current-tripleo"
+	DesignateAPIContainerImage = "quay.io/podified-antelope-centos9/openstack-designate-api:current-podified"
 	// DesignateCentralContainerImage is the fall-back container image for DesignateCentral
-	DesignateCentralContainerImage = "quay.io/tripleowallabycentos9/openstack-designate-central:current-tripleo"
+	DesignateCentralContainerImage = "quay.io/podified-antelope-centos9/openstack-designate-central:current-podified"
 	// DesignateMdnsContainerImage is the fall-back container image for DesignateMdns
-	DesignateMdnsContainerImage = "quay.io/tripleowallabycentos9/openstack-designate-mdns:current-tripleo"
+	DesignateMdnsContainerImage = "quay.io/podified-antelope-centos9/openstack-designate-mdns:current-podified"
 	// DesignateProducerContainerImage is the fall-back container image for DesignateProducer
-	DesignateProducerContainerImage = "quay.io/tripleowallabycentos9/openstack-designate-producer:current-tripleo"
+	DesignateProducerContainerImage = "quay.io/podified-antelope-centos9/openstack-designate-producer:current-podified"
 	// DesignateWorkerContainerImage is the fall-back container image for DesignateWorker
-	DesignateWorkerContainerImage = "quay.io/tripleowallabycentos9/openstack-designate-worker:current-tripleo"
+	DesignateWorkerContainerImage = "quay.io/podified-antelope-centos9/openstack-designate-worker:current-podified"
 	// DesignateUnboundContainerImage is the fall-back container image for DesignateUnbound
-	DesignateUnboundContainerImage = "quay.io/tripleowallabycentos9/openstack-unbound:current-tripleo"
+	DesignateUnboundContainerImage = "quay.io/podified-antelope-centos9/openstack-unbound:current-podified"
 	// DesignateBackendbind9ContainerImage is the fall-back container image for DesignateUnbound
-	DesignateBackendbind9ContainerImage = "quay.io/tripleowallabycentos9/openstack-designate-backend-bind9:current-tripleo"
+	DesignateBackendbind9ContainerImage = "quay.io/podified-antelope-centos9/openstack-designate-backend-bind9:current-podified"
 )
 
 // DesignateTemplate defines common input parameters used by all Designate services

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -12,16 +12,16 @@ spec:
       - name: manager
         env:
         - name: RELATED_IMAGE_DESIGNATE_API_IMAGE_URL_DEFAULT
-          value: quay.io/tripleowallabycentos9/openstack-designate-api:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-designate-api:current-podified
         - name: RELATED_IMAGE_DESIGNATE_CENTRAL_IMAGE_URL_DEFAULT
-          value: quay.io/tripleowallabycentos9/openstack-designate-central:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-designate-central:current-podified
         - name: RELATED_IMAGE_DESIGNATE_MDNS_IMAGE_URL_DEFAULT
-          value: quay.io/tripleowallabycentos9/openstack-designate-mdns:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-designate-mdns:current-podified
         - name: RELATED_IMAGE_DESIGNATE_PRODUCER_IMAGE_URL_DEFAULT
-          value: quay.io/tripleowallabycentos9/openstack-designate-producer:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-designate-producer:current-podified
         - name: RELATED_IMAGE_DESIGNATE_WORKER_IMAGE_URL_DEFAULT
-          value: quay.io/tripleowallabycentos9/openstack-designate-worker:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-designate-worker:current-podified
         - name: RELATED_IMAGE_DESIGNATE_BACKENDBIND9_IMAGE_URL_DEFAULT
-          value: quay.io/tripleowallabycentos9/openstack-designate-backend-bind9:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-designate-backend-bind9:current-podified
         - name: RELATED_IMAGE_DESIGNATE_UNBOUND_IMAGE_URL_DEFAULT
-          value: quay.io/tripleowallabycentos9/openstack-unbound:current-tripleo
+          value: quay.io/podified-antelope-centos9/openstack-unbound:current-podified


### PR DESCRIPTION
Prior to a fix to the mariadb operator, we were unable to properly initialize the database for the designate. This has been resolved so the current container images should work.