### PR TITLE
migrate from databaseUsername to databaseAccount and fully use MariaDBAccount

### DIFF
--- a/api/bases/designate.openstack.org_designateapis.yaml
+++ b/api/bases/designate.openstack.org_designateapis.yaml
@@ -84,14 +84,13 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: designate
+                description: DatabaseAccount - name of MariaDBAccount which will be
+                  used to connect.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Designate Database Hostname
-                type: string
-              databaseUser:
-                default: designate
-                description: 'DatabaseUser - optional username used for designate
-                  DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                  right now only designate'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -290,17 +289,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: DesignateDatabasePassword
                   service: DesignatePassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: DesignateDatabasePassword
-                    description: 'Database - Selector to get the designate database
-                      user password from the Secret TODO: not used, need change in
-                      mariadb-operator'
-                    type: string
                   service:
                     default: DesignatePassword
                     description: Service - Selector to get the designate service password
@@ -365,7 +357,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  DesignateDatabasePassword
+                  DesignatePassword
                 type: string
               serviceAccount:
                 description: ServiceAccount - service account name used internally

--- a/api/bases/designate.openstack.org_designatebackendbind9s.yaml
+++ b/api/bases/designate.openstack.org_designatebackendbind9s.yaml
@@ -80,14 +80,13 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: designate
+                description: DatabaseAccount - name of MariaDBAccount which will be
+                  used to connect.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Designate Database Hostname
-                type: string
-              databaseUser:
-                default: designate
-                description: 'DatabaseUser - optional username used for designate
-                  DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                  right now only designate'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -112,17 +111,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: DesignateDatabasePassword
                   service: DesignatePassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: DesignateDatabasePassword
-                    description: 'Database - Selector to get the designate database
-                      user password from the Secret TODO: not used, need change in
-                      mariadb-operator'
-                    type: string
                   service:
                     default: DesignatePassword
                     description: Service - Selector to get the designate service password
@@ -187,7 +179,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  DesignateDatabasePassword
+                  DesignatePassword
                 type: string
               serviceAccount:
                 description: ServiceAccount - service account name used internally

--- a/api/bases/designate.openstack.org_designatecentrals.yaml
+++ b/api/bases/designate.openstack.org_designatecentrals.yaml
@@ -84,14 +84,13 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: designate
+                description: DatabaseAccount - name of MariaDBAccount which will be
+                  used to connect.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Designate Database Hostname
-                type: string
-              databaseUser:
-                default: designate
-                description: 'DatabaseUser - optional username used for designate
-                  DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                  right now only designate'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -116,17 +115,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: DesignateDatabasePassword
                   service: DesignatePassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: DesignateDatabasePassword
-                    description: 'Database - Selector to get the designate database
-                      user password from the Secret TODO: not used, need change in
-                      mariadb-operator'
-                    type: string
                   service:
                     default: DesignatePassword
                     description: Service - Selector to get the designate service password
@@ -191,7 +183,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  DesignateDatabasePassword
+                  DesignatePassword
                 type: string
               serviceAccount:
                 description: ServiceAccount - service account name used internally

--- a/api/bases/designate.openstack.org_designatemdnses.yaml
+++ b/api/bases/designate.openstack.org_designatemdnses.yaml
@@ -84,14 +84,13 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: designate
+                description: DatabaseAccount - name of MariaDBAccount which will be
+                  used to connect.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Designate Database Hostname
-                type: string
-              databaseUser:
-                default: designate
-                description: 'DatabaseUser - optional username used for designate
-                  DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                  right now only designate'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -116,17 +115,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: DesignateDatabasePassword
                   service: DesignatePassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: DesignateDatabasePassword
-                    description: 'Database - Selector to get the designate database
-                      user password from the Secret TODO: not used, need change in
-                      mariadb-operator'
-                    type: string
                   service:
                     default: DesignatePassword
                     description: Service - Selector to get the designate service password
@@ -191,7 +183,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  DesignateDatabasePassword
+                  DesignatePassword
                 type: string
               serviceAccount:
                 description: ServiceAccount - service account name used internally

--- a/api/bases/designate.openstack.org_designateproducers.yaml
+++ b/api/bases/designate.openstack.org_designateproducers.yaml
@@ -84,14 +84,13 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: designate
+                description: DatabaseAccount - name of MariaDBAccount which will be
+                  used to connect.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Designate Database Hostname
-                type: string
-              databaseUser:
-                default: designate
-                description: 'DatabaseUser - optional username used for designate
-                  DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                  right now only designate'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -116,17 +115,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: DesignateDatabasePassword
                   service: DesignatePassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: DesignateDatabasePassword
-                    description: 'Database - Selector to get the designate database
-                      user password from the Secret TODO: not used, need change in
-                      mariadb-operator'
-                    type: string
                   service:
                     default: DesignatePassword
                     description: Service - Selector to get the designate service password
@@ -191,7 +183,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  DesignateDatabasePassword
+                  DesignatePassword
                 type: string
               serviceAccount:
                 description: ServiceAccount - service account name used internally

--- a/api/bases/designate.openstack.org_designates.yaml
+++ b/api/bases/designate.openstack.org_designates.yaml
@@ -69,16 +69,15 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: designate
+                description: DatabaseAccount - name of MariaDBAccount which will be
+                  used to connect.
+                type: string
               databaseInstance:
                 description: MariaDB instance name Right now required by the maridb-operator
                   to get the credentials from the instance to create the DB Might
                   not be required in future
-                type: string
-              databaseUser:
-                default: designate
-                description: 'DatabaseUser - optional username used for designate
-                  DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                  right now only designate'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -129,14 +128,13 @@ spec:
                     items:
                       type: string
                     type: array
+                  databaseAccount:
+                    default: designate
+                    description: DatabaseAccount - name of MariaDBAccount which will
+                      be used to connect.
+                    type: string
                   databaseHostname:
                     description: DatabaseHostname - Designate Database Hostname
-                    type: string
-                  databaseUser:
-                    default: designate
-                    description: 'DatabaseUser - optional username used for designate
-                      DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                      right now only designate'
                     type: string
                   defaultConfigOverwrite:
                     additionalProperties:
@@ -343,17 +341,10 @@ spec:
                     type: object
                   passwordSelectors:
                     default:
-                      database: DesignateDatabasePassword
                       service: DesignatePassword
                     description: PasswordSelectors - Selectors to identify the DB
                       and ServiceUser password from the Secret
                     properties:
-                      database:
-                        default: DesignateDatabasePassword
-                        description: 'Database - Selector to get the designate database
-                          user password from the Secret TODO: not used, need change
-                          in mariadb-operator'
-                        type: string
                       service:
                         default: DesignatePassword
                         description: Service - Selector to get the designate service
@@ -419,7 +410,7 @@ spec:
                     type: object
                   secret:
                     description: Secret containing OpenStack password information
-                      for DesignateDatabasePassword
+                      for DesignatePassword
                     type: string
                   serviceAccount:
                     description: ServiceAccount - service account name used internally
@@ -477,14 +468,13 @@ spec:
                     items:
                       type: string
                     type: array
+                  databaseAccount:
+                    default: designate
+                    description: DatabaseAccount - name of MariaDBAccount which will
+                      be used to connect.
+                    type: string
                   databaseHostname:
                     description: DatabaseHostname - Designate Database Hostname
-                    type: string
-                  databaseUser:
-                    default: designate
-                    description: 'DatabaseUser - optional username used for designate
-                      DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                      right now only designate'
                     type: string
                   defaultConfigOverwrite:
                     additionalProperties:
@@ -509,17 +499,10 @@ spec:
                     type: object
                   passwordSelectors:
                     default:
-                      database: DesignateDatabasePassword
                       service: DesignatePassword
                     description: PasswordSelectors - Selectors to identify the DB
                       and ServiceUser password from the Secret
                     properties:
-                      database:
-                        default: DesignateDatabasePassword
-                        description: 'Database - Selector to get the designate database
-                          user password from the Secret TODO: not used, need change
-                          in mariadb-operator'
-                        type: string
                       service:
                         default: DesignatePassword
                         description: Service - Selector to get the designate service
@@ -585,7 +568,7 @@ spec:
                     type: object
                   secret:
                     description: Secret containing OpenStack password information
-                      for DesignateDatabasePassword
+                      for DesignatePassword
                     type: string
                   serviceAccount:
                     description: ServiceAccount - service account name used internally
@@ -643,14 +626,13 @@ spec:
                     items:
                       type: string
                     type: array
+                  databaseAccount:
+                    default: designate
+                    description: DatabaseAccount - name of MariaDBAccount which will
+                      be used to connect.
+                    type: string
                   databaseHostname:
                     description: DatabaseHostname - Designate Database Hostname
-                    type: string
-                  databaseUser:
-                    default: designate
-                    description: 'DatabaseUser - optional username used for designate
-                      DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                      right now only designate'
                     type: string
                   defaultConfigOverwrite:
                     additionalProperties:
@@ -675,17 +657,10 @@ spec:
                     type: object
                   passwordSelectors:
                     default:
-                      database: DesignateDatabasePassword
                       service: DesignatePassword
                     description: PasswordSelectors - Selectors to identify the DB
                       and ServiceUser password from the Secret
                     properties:
-                      database:
-                        default: DesignateDatabasePassword
-                        description: 'Database - Selector to get the designate database
-                          user password from the Secret TODO: not used, need change
-                          in mariadb-operator'
-                        type: string
                       service:
                         default: DesignatePassword
                         description: Service - Selector to get the designate service
@@ -751,7 +726,7 @@ spec:
                     type: object
                   secret:
                     description: Secret containing OpenStack password information
-                      for DesignateDatabasePassword
+                      for DesignatePassword
                     type: string
                   serviceAccount:
                     description: ServiceAccount - service account name used internally
@@ -809,14 +784,13 @@ spec:
                     items:
                       type: string
                     type: array
+                  databaseAccount:
+                    default: designate
+                    description: DatabaseAccount - name of MariaDBAccount which will
+                      be used to connect.
+                    type: string
                   databaseHostname:
                     description: DatabaseHostname - Designate Database Hostname
-                    type: string
-                  databaseUser:
-                    default: designate
-                    description: 'DatabaseUser - optional username used for designate
-                      DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                      right now only designate'
                     type: string
                   defaultConfigOverwrite:
                     additionalProperties:
@@ -841,17 +815,10 @@ spec:
                     type: object
                   passwordSelectors:
                     default:
-                      database: DesignateDatabasePassword
                       service: DesignatePassword
                     description: PasswordSelectors - Selectors to identify the DB
                       and ServiceUser password from the Secret
                     properties:
-                      database:
-                        default: DesignateDatabasePassword
-                        description: 'Database - Selector to get the designate database
-                          user password from the Secret TODO: not used, need change
-                          in mariadb-operator'
-                        type: string
                       service:
                         default: DesignatePassword
                         description: Service - Selector to get the designate service
@@ -917,7 +884,7 @@ spec:
                     type: object
                   secret:
                     description: Secret containing OpenStack password information
-                      for DesignateDatabasePassword
+                      for DesignatePassword
                     type: string
                   serviceAccount:
                     description: ServiceAccount - service account name used internally
@@ -975,14 +942,13 @@ spec:
                     items:
                       type: string
                     type: array
+                  databaseAccount:
+                    default: designate
+                    description: DatabaseAccount - name of MariaDBAccount which will
+                      be used to connect.
+                    type: string
                   databaseHostname:
                     description: DatabaseHostname - Designate Database Hostname
-                    type: string
-                  databaseUser:
-                    default: designate
-                    description: 'DatabaseUser - optional username used for designate
-                      DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                      right now only designate'
                     type: string
                   defaultConfigOverwrite:
                     additionalProperties:
@@ -1007,17 +973,10 @@ spec:
                     type: object
                   passwordSelectors:
                     default:
-                      database: DesignateDatabasePassword
                       service: DesignatePassword
                     description: PasswordSelectors - Selectors to identify the DB
                       and ServiceUser password from the Secret
                     properties:
-                      database:
-                        default: DesignateDatabasePassword
-                        description: 'Database - Selector to get the designate database
-                          user password from the Secret TODO: not used, need change
-                          in mariadb-operator'
-                        type: string
                       service:
                         default: DesignatePassword
                         description: Service - Selector to get the designate service
@@ -1083,7 +1042,7 @@ spec:
                     type: object
                   secret:
                     description: Secret containing OpenStack password information
-                      for DesignateDatabasePassword
+                      for DesignatePassword
                     type: string
                   serviceAccount:
                     description: ServiceAccount - service account name used internally
@@ -1250,14 +1209,13 @@ spec:
                     items:
                       type: string
                     type: array
+                  databaseAccount:
+                    default: designate
+                    description: DatabaseAccount - name of MariaDBAccount which will
+                      be used to connect.
+                    type: string
                   databaseHostname:
                     description: DatabaseHostname - Designate Database Hostname
-                    type: string
-                  databaseUser:
-                    default: designate
-                    description: 'DatabaseUser - optional username used for designate
-                      DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                      right now only designate'
                     type: string
                   defaultConfigOverwrite:
                     additionalProperties:
@@ -1282,17 +1240,10 @@ spec:
                     type: object
                   passwordSelectors:
                     default:
-                      database: DesignateDatabasePassword
                       service: DesignatePassword
                     description: PasswordSelectors - Selectors to identify the DB
                       and ServiceUser password from the Secret
                     properties:
-                      database:
-                        default: DesignateDatabasePassword
-                        description: 'Database - Selector to get the designate database
-                          user password from the Secret TODO: not used, need change
-                          in mariadb-operator'
-                        type: string
                       service:
                         default: DesignatePassword
                         description: Service - Selector to get the designate service
@@ -1358,7 +1309,7 @@ spec:
                     type: object
                   secret:
                     description: Secret containing OpenStack password information
-                      for DesignateDatabasePassword
+                      for DesignatePassword
                     type: string
                   serviceAccount:
                     description: ServiceAccount - service account name used internally
@@ -1383,17 +1334,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: DesignateDatabasePassword
                   service: DesignatePassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   AdminUser password from the Secret
                 properties:
-                  database:
-                    default: DesignateDatabasePassword
-                    description: 'Database - Selector to get the designate database
-                      user password from the Secret TODO: not used, need change in
-                      mariadb-operator'
-                    type: string
                   service:
                     default: DesignatePassword
                     description: Service - Selector to get the designate service password
@@ -1461,7 +1405,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  designate DesignateDatabasePassword, AdminPassword
+                  designate AdminPassword
                 type: string
               serviceUser:
                 default: designate

--- a/api/bases/designate.openstack.org_designateworkers.yaml
+++ b/api/bases/designate.openstack.org_designateworkers.yaml
@@ -80,14 +80,13 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: designate
+                description: DatabaseAccount - name of MariaDBAccount which will be
+                  used to connect.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Designate Database Hostname
-                type: string
-              databaseUser:
-                default: designate
-                description: 'DatabaseUser - optional username used for designate
-                  DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                  right now only designate'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -112,17 +111,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: DesignateDatabasePassword
                   service: DesignatePassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: DesignateDatabasePassword
-                    description: 'Database - Selector to get the designate database
-                      user password from the Secret TODO: not used, need change in
-                      mariadb-operator'
-                    type: string
                   service:
                     default: DesignatePassword
                     description: Service - Selector to get the designate service password
@@ -187,7 +179,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  DesignateDatabasePassword
+                  DesignatePassword
                 type: string
               serviceAccount:
                 description: ServiceAccount - service account name used internally

--- a/api/go.mod
+++ b/api/go.mod
@@ -3,7 +3,7 @@ module github.com/openstack-k8s-operators/designate-operator/api
 go 1.20
 
 require (
-	github.com/onsi/ginkgo/v2 v2.14.0
+	github.com/onsi/ginkgo/v2 v2.15.0
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240216173409-86913e6d5885
 	github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240216173409-86913e6d5885
 	k8s.io/api v0.28.3
@@ -12,7 +12,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.16.4
 )
 
-require github.com/onsi/gomega v1.30.0
+require github.com/onsi/gomega v1.31.1
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -81,10 +81,10 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY=
-github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
-github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
-github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY=
+github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
+github.com/onsi/gomega v1.31.1 h1:KYppCUK+bUgAZwHOu7EXVBKyQA6ILvOESHkn/tgoqvo=
+github.com/onsi/gomega v1.31.1/go.mod h1:y40C95dwAD1Nz36SsEnxvfFe8FFfNxzI5eJ0EYGyAy0=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240216173409-86913e6d5885 h1:o7KZaxKt8Dr97ZJIBPW0P482gLyFEURKF89fizcJCBQ=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:bQwzyQtWCR9F0+IvWZ30J9d1lB6tcX3CNJ0Ten1smDw=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240216173409-86913e6d5885 h1:sMO+IYsZ91Nho0FV6y03J0NTGd8+ZWB4KmKJJU94gTU=

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -49,16 +49,15 @@ type DesignateTemplate struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=designate
-	// DatabaseUser - optional username used for designate DB, defaults to designate
-	// TODO: -> implement needs work in mariadb-operator, right now only designate
-	DatabaseUser string `json:"databaseUser"`
+	// DatabaseAccount - name of MariaDBAccount which will be used to connect.
+	DatabaseAccount string `json:"databaseAccount"`
 
 	// +kubebuilder:validation:Optional
-	// Secret containing OpenStack password information for DesignateDatabasePassword
+	// Secret containing OpenStack password information for DesignatePassword
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: DesignateDatabasePassword, service: DesignatePassword}
+	// +kubebuilder:default={service: DesignatePassword}
 	// PasswordSelectors - Selectors to identify the DB and ServiceUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors"`
 
@@ -122,11 +121,6 @@ type DesignateServiceTemplate struct {
 
 // PasswordSelector to identify the DB and AdminUser password from the Secret
 type PasswordSelector struct {
-	// +kubebuilder:validation:Optional
-	// +kubebuilder:default="DesignateDatabasePassword"
-	// Database - Selector to get the designate database user password from the Secret
-	// TODO: not used, need change in mariadb-operator
-	Database string `json:"database"`
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="DesignatePassword"
 	// Service - Selector to get the designate service password from the Secret

--- a/api/v1beta1/designate_types.go
+++ b/api/v1beta1/designate_types.go
@@ -55,9 +55,8 @@ type DesignateSpec struct {
 
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=designate
-	// DatabaseUser - optional username used for designate DB, defaults to designate
-	// TODO: -> implement needs work in mariadb-operator, right now only designate
-	DatabaseUser string `json:"databaseUser"`
+	// DatabaseAccount - name of MariaDBAccount which will be used to connect.
+	DatabaseAccount string `json:"databaseAccount"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default=rabbitmq
@@ -66,11 +65,11 @@ type DesignateSpec struct {
 	RabbitMqClusterName string `json:"rabbitMqClusterName"`
 
 	// +kubebuilder:validation:Required
-	// Secret containing OpenStack password information for designate DesignateDatabasePassword, AdminPassword
+	// Secret containing OpenStack password information for designate AdminPassword
 	Secret string `json:"secret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default={database: DesignateDatabasePassword, service: DesignatePassword}
+	// +kubebuilder:default={service: DesignatePassword}
 	// PasswordSelectors - Selectors to identify the DB and AdminUser password from the Secret
 	PasswordSelectors PasswordSelector `json:"passwordSelectors,omitempty"`
 

--- a/config/crd/bases/designate.openstack.org_designateapis.yaml
+++ b/config/crd/bases/designate.openstack.org_designateapis.yaml
@@ -84,14 +84,13 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: designate
+                description: DatabaseAccount - name of MariaDBAccount which will be
+                  used to connect.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Designate Database Hostname
-                type: string
-              databaseUser:
-                default: designate
-                description: 'DatabaseUser - optional username used for designate
-                  DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                  right now only designate'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -290,17 +289,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: DesignateDatabasePassword
                   service: DesignatePassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: DesignateDatabasePassword
-                    description: 'Database - Selector to get the designate database
-                      user password from the Secret TODO: not used, need change in
-                      mariadb-operator'
-                    type: string
                   service:
                     default: DesignatePassword
                     description: Service - Selector to get the designate service password
@@ -365,7 +357,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  DesignateDatabasePassword
+                  DesignatePassword
                 type: string
               serviceAccount:
                 description: ServiceAccount - service account name used internally

--- a/config/crd/bases/designate.openstack.org_designatebackendbind9s.yaml
+++ b/config/crd/bases/designate.openstack.org_designatebackendbind9s.yaml
@@ -80,14 +80,13 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: designate
+                description: DatabaseAccount - name of MariaDBAccount which will be
+                  used to connect.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Designate Database Hostname
-                type: string
-              databaseUser:
-                default: designate
-                description: 'DatabaseUser - optional username used for designate
-                  DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                  right now only designate'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -112,17 +111,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: DesignateDatabasePassword
                   service: DesignatePassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: DesignateDatabasePassword
-                    description: 'Database - Selector to get the designate database
-                      user password from the Secret TODO: not used, need change in
-                      mariadb-operator'
-                    type: string
                   service:
                     default: DesignatePassword
                     description: Service - Selector to get the designate service password
@@ -187,7 +179,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  DesignateDatabasePassword
+                  DesignatePassword
                 type: string
               serviceAccount:
                 description: ServiceAccount - service account name used internally

--- a/config/crd/bases/designate.openstack.org_designatecentrals.yaml
+++ b/config/crd/bases/designate.openstack.org_designatecentrals.yaml
@@ -84,14 +84,13 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: designate
+                description: DatabaseAccount - name of MariaDBAccount which will be
+                  used to connect.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Designate Database Hostname
-                type: string
-              databaseUser:
-                default: designate
-                description: 'DatabaseUser - optional username used for designate
-                  DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                  right now only designate'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -116,17 +115,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: DesignateDatabasePassword
                   service: DesignatePassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: DesignateDatabasePassword
-                    description: 'Database - Selector to get the designate database
-                      user password from the Secret TODO: not used, need change in
-                      mariadb-operator'
-                    type: string
                   service:
                     default: DesignatePassword
                     description: Service - Selector to get the designate service password
@@ -191,7 +183,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  DesignateDatabasePassword
+                  DesignatePassword
                 type: string
               serviceAccount:
                 description: ServiceAccount - service account name used internally

--- a/config/crd/bases/designate.openstack.org_designatemdnses.yaml
+++ b/config/crd/bases/designate.openstack.org_designatemdnses.yaml
@@ -84,14 +84,13 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: designate
+                description: DatabaseAccount - name of MariaDBAccount which will be
+                  used to connect.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Designate Database Hostname
-                type: string
-              databaseUser:
-                default: designate
-                description: 'DatabaseUser - optional username used for designate
-                  DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                  right now only designate'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -116,17 +115,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: DesignateDatabasePassword
                   service: DesignatePassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: DesignateDatabasePassword
-                    description: 'Database - Selector to get the designate database
-                      user password from the Secret TODO: not used, need change in
-                      mariadb-operator'
-                    type: string
                   service:
                     default: DesignatePassword
                     description: Service - Selector to get the designate service password
@@ -191,7 +183,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  DesignateDatabasePassword
+                  DesignatePassword
                 type: string
               serviceAccount:
                 description: ServiceAccount - service account name used internally

--- a/config/crd/bases/designate.openstack.org_designateproducers.yaml
+++ b/config/crd/bases/designate.openstack.org_designateproducers.yaml
@@ -84,14 +84,13 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: designate
+                description: DatabaseAccount - name of MariaDBAccount which will be
+                  used to connect.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Designate Database Hostname
-                type: string
-              databaseUser:
-                default: designate
-                description: 'DatabaseUser - optional username used for designate
-                  DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                  right now only designate'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -116,17 +115,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: DesignateDatabasePassword
                   service: DesignatePassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: DesignateDatabasePassword
-                    description: 'Database - Selector to get the designate database
-                      user password from the Secret TODO: not used, need change in
-                      mariadb-operator'
-                    type: string
                   service:
                     default: DesignatePassword
                     description: Service - Selector to get the designate service password
@@ -191,7 +183,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  DesignateDatabasePassword
+                  DesignatePassword
                 type: string
               serviceAccount:
                 description: ServiceAccount - service account name used internally

--- a/config/crd/bases/designate.openstack.org_designates.yaml
+++ b/config/crd/bases/designate.openstack.org_designates.yaml
@@ -69,16 +69,15 @@ spec:
                   added to to /etc/<service>/<service>.conf.d directory as custom.conf
                   file.
                 type: string
+              databaseAccount:
+                default: designate
+                description: DatabaseAccount - name of MariaDBAccount which will be
+                  used to connect.
+                type: string
               databaseInstance:
                 description: MariaDB instance name Right now required by the maridb-operator
                   to get the credentials from the instance to create the DB Might
                   not be required in future
-                type: string
-              databaseUser:
-                default: designate
-                description: 'DatabaseUser - optional username used for designate
-                  DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                  right now only designate'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -129,14 +128,13 @@ spec:
                     items:
                       type: string
                     type: array
+                  databaseAccount:
+                    default: designate
+                    description: DatabaseAccount - name of MariaDBAccount which will
+                      be used to connect.
+                    type: string
                   databaseHostname:
                     description: DatabaseHostname - Designate Database Hostname
-                    type: string
-                  databaseUser:
-                    default: designate
-                    description: 'DatabaseUser - optional username used for designate
-                      DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                      right now only designate'
                     type: string
                   defaultConfigOverwrite:
                     additionalProperties:
@@ -343,17 +341,10 @@ spec:
                     type: object
                   passwordSelectors:
                     default:
-                      database: DesignateDatabasePassword
                       service: DesignatePassword
                     description: PasswordSelectors - Selectors to identify the DB
                       and ServiceUser password from the Secret
                     properties:
-                      database:
-                        default: DesignateDatabasePassword
-                        description: 'Database - Selector to get the designate database
-                          user password from the Secret TODO: not used, need change
-                          in mariadb-operator'
-                        type: string
                       service:
                         default: DesignatePassword
                         description: Service - Selector to get the designate service
@@ -419,7 +410,7 @@ spec:
                     type: object
                   secret:
                     description: Secret containing OpenStack password information
-                      for DesignateDatabasePassword
+                      for DesignatePassword
                     type: string
                   serviceAccount:
                     description: ServiceAccount - service account name used internally
@@ -477,14 +468,13 @@ spec:
                     items:
                       type: string
                     type: array
+                  databaseAccount:
+                    default: designate
+                    description: DatabaseAccount - name of MariaDBAccount which will
+                      be used to connect.
+                    type: string
                   databaseHostname:
                     description: DatabaseHostname - Designate Database Hostname
-                    type: string
-                  databaseUser:
-                    default: designate
-                    description: 'DatabaseUser - optional username used for designate
-                      DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                      right now only designate'
                     type: string
                   defaultConfigOverwrite:
                     additionalProperties:
@@ -509,17 +499,10 @@ spec:
                     type: object
                   passwordSelectors:
                     default:
-                      database: DesignateDatabasePassword
                       service: DesignatePassword
                     description: PasswordSelectors - Selectors to identify the DB
                       and ServiceUser password from the Secret
                     properties:
-                      database:
-                        default: DesignateDatabasePassword
-                        description: 'Database - Selector to get the designate database
-                          user password from the Secret TODO: not used, need change
-                          in mariadb-operator'
-                        type: string
                       service:
                         default: DesignatePassword
                         description: Service - Selector to get the designate service
@@ -585,7 +568,7 @@ spec:
                     type: object
                   secret:
                     description: Secret containing OpenStack password information
-                      for DesignateDatabasePassword
+                      for DesignatePassword
                     type: string
                   serviceAccount:
                     description: ServiceAccount - service account name used internally
@@ -643,14 +626,13 @@ spec:
                     items:
                       type: string
                     type: array
+                  databaseAccount:
+                    default: designate
+                    description: DatabaseAccount - name of MariaDBAccount which will
+                      be used to connect.
+                    type: string
                   databaseHostname:
                     description: DatabaseHostname - Designate Database Hostname
-                    type: string
-                  databaseUser:
-                    default: designate
-                    description: 'DatabaseUser - optional username used for designate
-                      DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                      right now only designate'
                     type: string
                   defaultConfigOverwrite:
                     additionalProperties:
@@ -675,17 +657,10 @@ spec:
                     type: object
                   passwordSelectors:
                     default:
-                      database: DesignateDatabasePassword
                       service: DesignatePassword
                     description: PasswordSelectors - Selectors to identify the DB
                       and ServiceUser password from the Secret
                     properties:
-                      database:
-                        default: DesignateDatabasePassword
-                        description: 'Database - Selector to get the designate database
-                          user password from the Secret TODO: not used, need change
-                          in mariadb-operator'
-                        type: string
                       service:
                         default: DesignatePassword
                         description: Service - Selector to get the designate service
@@ -751,7 +726,7 @@ spec:
                     type: object
                   secret:
                     description: Secret containing OpenStack password information
-                      for DesignateDatabasePassword
+                      for DesignatePassword
                     type: string
                   serviceAccount:
                     description: ServiceAccount - service account name used internally
@@ -809,14 +784,13 @@ spec:
                     items:
                       type: string
                     type: array
+                  databaseAccount:
+                    default: designate
+                    description: DatabaseAccount - name of MariaDBAccount which will
+                      be used to connect.
+                    type: string
                   databaseHostname:
                     description: DatabaseHostname - Designate Database Hostname
-                    type: string
-                  databaseUser:
-                    default: designate
-                    description: 'DatabaseUser - optional username used for designate
-                      DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                      right now only designate'
                     type: string
                   defaultConfigOverwrite:
                     additionalProperties:
@@ -841,17 +815,10 @@ spec:
                     type: object
                   passwordSelectors:
                     default:
-                      database: DesignateDatabasePassword
                       service: DesignatePassword
                     description: PasswordSelectors - Selectors to identify the DB
                       and ServiceUser password from the Secret
                     properties:
-                      database:
-                        default: DesignateDatabasePassword
-                        description: 'Database - Selector to get the designate database
-                          user password from the Secret TODO: not used, need change
-                          in mariadb-operator'
-                        type: string
                       service:
                         default: DesignatePassword
                         description: Service - Selector to get the designate service
@@ -917,7 +884,7 @@ spec:
                     type: object
                   secret:
                     description: Secret containing OpenStack password information
-                      for DesignateDatabasePassword
+                      for DesignatePassword
                     type: string
                   serviceAccount:
                     description: ServiceAccount - service account name used internally
@@ -975,14 +942,13 @@ spec:
                     items:
                       type: string
                     type: array
+                  databaseAccount:
+                    default: designate
+                    description: DatabaseAccount - name of MariaDBAccount which will
+                      be used to connect.
+                    type: string
                   databaseHostname:
                     description: DatabaseHostname - Designate Database Hostname
-                    type: string
-                  databaseUser:
-                    default: designate
-                    description: 'DatabaseUser - optional username used for designate
-                      DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                      right now only designate'
                     type: string
                   defaultConfigOverwrite:
                     additionalProperties:
@@ -1007,17 +973,10 @@ spec:
                     type: object
                   passwordSelectors:
                     default:
-                      database: DesignateDatabasePassword
                       service: DesignatePassword
                     description: PasswordSelectors - Selectors to identify the DB
                       and ServiceUser password from the Secret
                     properties:
-                      database:
-                        default: DesignateDatabasePassword
-                        description: 'Database - Selector to get the designate database
-                          user password from the Secret TODO: not used, need change
-                          in mariadb-operator'
-                        type: string
                       service:
                         default: DesignatePassword
                         description: Service - Selector to get the designate service
@@ -1083,7 +1042,7 @@ spec:
                     type: object
                   secret:
                     description: Secret containing OpenStack password information
-                      for DesignateDatabasePassword
+                      for DesignatePassword
                     type: string
                   serviceAccount:
                     description: ServiceAccount - service account name used internally
@@ -1250,14 +1209,13 @@ spec:
                     items:
                       type: string
                     type: array
+                  databaseAccount:
+                    default: designate
+                    description: DatabaseAccount - name of MariaDBAccount which will
+                      be used to connect.
+                    type: string
                   databaseHostname:
                     description: DatabaseHostname - Designate Database Hostname
-                    type: string
-                  databaseUser:
-                    default: designate
-                    description: 'DatabaseUser - optional username used for designate
-                      DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                      right now only designate'
                     type: string
                   defaultConfigOverwrite:
                     additionalProperties:
@@ -1282,17 +1240,10 @@ spec:
                     type: object
                   passwordSelectors:
                     default:
-                      database: DesignateDatabasePassword
                       service: DesignatePassword
                     description: PasswordSelectors - Selectors to identify the DB
                       and ServiceUser password from the Secret
                     properties:
-                      database:
-                        default: DesignateDatabasePassword
-                        description: 'Database - Selector to get the designate database
-                          user password from the Secret TODO: not used, need change
-                          in mariadb-operator'
-                        type: string
                       service:
                         default: DesignatePassword
                         description: Service - Selector to get the designate service
@@ -1358,7 +1309,7 @@ spec:
                     type: object
                   secret:
                     description: Secret containing OpenStack password information
-                      for DesignateDatabasePassword
+                      for DesignatePassword
                     type: string
                   serviceAccount:
                     description: ServiceAccount - service account name used internally
@@ -1383,17 +1334,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: DesignateDatabasePassword
                   service: DesignatePassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   AdminUser password from the Secret
                 properties:
-                  database:
-                    default: DesignateDatabasePassword
-                    description: 'Database - Selector to get the designate database
-                      user password from the Secret TODO: not used, need change in
-                      mariadb-operator'
-                    type: string
                   service:
                     default: DesignatePassword
                     description: Service - Selector to get the designate service password
@@ -1461,7 +1405,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  designate DesignateDatabasePassword, AdminPassword
+                  designate AdminPassword
                 type: string
               serviceUser:
                 default: designate

--- a/config/crd/bases/designate.openstack.org_designateworkers.yaml
+++ b/config/crd/bases/designate.openstack.org_designateworkers.yaml
@@ -80,14 +80,13 @@ spec:
                 items:
                   type: string
                 type: array
+              databaseAccount:
+                default: designate
+                description: DatabaseAccount - name of MariaDBAccount which will be
+                  used to connect.
+                type: string
               databaseHostname:
                 description: DatabaseHostname - Designate Database Hostname
-                type: string
-              databaseUser:
-                default: designate
-                description: 'DatabaseUser - optional username used for designate
-                  DB, defaults to designate TODO: -> implement needs work in mariadb-operator,
-                  right now only designate'
                 type: string
               defaultConfigOverwrite:
                 additionalProperties:
@@ -112,17 +111,10 @@ spec:
                 type: object
               passwordSelectors:
                 default:
-                  database: DesignateDatabasePassword
                   service: DesignatePassword
                 description: PasswordSelectors - Selectors to identify the DB and
                   ServiceUser password from the Secret
                 properties:
-                  database:
-                    default: DesignateDatabasePassword
-                    description: 'Database - Selector to get the designate database
-                      user password from the Secret TODO: not used, need change in
-                      mariadb-operator'
-                    type: string
                   service:
                     default: DesignatePassword
                     description: Service - Selector to get the designate service password
@@ -187,7 +179,7 @@ spec:
                 type: object
               secret:
                 description: Secret containing OpenStack password information for
-                  DesignateDatabasePassword
+                  DesignatePassword
                 type: string
               serviceAccount:
                 description: ServiceAccount - service account name used internally

--- a/config/samples/designate_v1beta1_designate.yaml
+++ b/config/samples/designate_v1beta1_designate.yaml
@@ -9,5 +9,5 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: designate
+  databaseAccount: designate
   rabbitMqClusterName: rabbitmq

--- a/config/samples/designate_v1beta1_designate_with_bind9.yaml
+++ b/config/samples/designate_v1beta1_designate_with_bind9.yaml
@@ -9,5 +9,5 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: designate
+  databaseAccount: designate
   rabbitMqClusterName: rabbitmq

--- a/controllers/designatecentral_controller.go
+++ b/controllers/designatecentral_controller.go
@@ -40,7 +40,6 @@ import (
 	designatecentral "github.com/openstack-k8s-operators/designate-operator/pkg/designatecentral"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/deployment"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -303,7 +302,7 @@ func (r *DesignateCentralReconciler) reconcileNormal(ctx context.Context, instan
 	//
 	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
 	//
-	ctrlResult, err := r.getSecret(ctx, helper, instance, instance.Spec.Secret, &configMapVars)
+	ctrlResult, err := r.getSecret(ctx, helper, instance, instance.Spec.Secret, &configMapVars, "secret-")
 	if err != nil {
 		return ctrlResult, err
 	}
@@ -312,7 +311,7 @@ func (r *DesignateCentralReconciler) reconcileNormal(ctx context.Context, instan
 	//
 	// check for required TransportURL secret holding transport URL string
 	//
-	ctrlResult, err = r.getSecret(ctx, helper, instance, instance.Spec.TransportURLSecret, &configMapVars)
+	ctrlResult, err = r.getSecret(ctx, helper, instance, instance.Spec.TransportURLSecret, &configMapVars, "secret-")
 	if err != nil {
 		return ctrlResult, err
 	}
@@ -322,7 +321,7 @@ func (r *DesignateCentralReconciler) reconcileNormal(ctx context.Context, instan
 	// check for required service secrets
 	//
 	for _, secretName := range instance.Spec.CustomServiceConfigSecrets {
-		ctrlResult, err = r.getSecret(ctx, helper, instance, secretName, &configMapVars)
+		ctrlResult, err = r.getSecret(ctx, helper, instance, secretName, &configMapVars, "secret-")
 		if err != nil {
 			return ctrlResult, err
 		}
@@ -336,29 +335,17 @@ func (r *DesignateCentralReconciler) reconcileNormal(ctx context.Context, instan
 	parentDesignateName := designate.GetOwningDesignateName(instance)
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' init: parent name: %s", instance.Name, parentDesignateName))
 
-	configMaps := []string{
-		fmt.Sprintf("%s-scripts", parentDesignateName),     // ScriptsConfigMap
-		fmt.Sprintf("%s-config-data", parentDesignateName), // ConfigMap
+	ctrlResult, err = r.getSecret(ctx, helper, instance, fmt.Sprintf("%s-scripts", parentDesignateName), &configMapVars, "")
+	if err != nil {
+		return ctrlResult, err
+	}
+	ctrlResult, err = r.getSecret(ctx, helper, instance, fmt.Sprintf("%s-config-data", parentDesignateName), &configMapVars, "")
+	// note r.getSecret adds Conditions with condition.InputReadyWaitingMessage
+	// when secret is not found
+	if err != nil {
+		return ctrlResult, err
 	}
 
-	_, err = configmap.GetConfigMaps(ctx, helper, instance, configMaps, instance.Namespace, &configMapVars)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
-				condition.InputReadyWaitingMessage))
-			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("Could not find all config maps for parent Designate CR %s", parentDesignateName)
-		}
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 	// run check parent Designate CR config maps - end
 
@@ -568,6 +555,7 @@ func (r *DesignateCentralReconciler) getSecret(
 	instance *designatev1beta1.DesignateCentral,
 	secretName string,
 	envVars *map[string]env.Setter,
+	prefix string,
 ) (ctrl.Result, error) {
 	secret, hash, err := secret.GetSecret(ctx, h, secretName, instance.Namespace)
 	if err != nil {
@@ -590,7 +578,7 @@ func (r *DesignateCentralReconciler) getSecret(
 
 	// Add a prefix to the var name to avoid accidental collision with other non-secret
 	// vars. The secret names themselves will be unique.
-	(*envVars)["secret-"+secret.Name] = env.SetValue(hash)
+	(*envVars)[prefix+secret.Name] = env.SetValue(hash)
 
 	return ctrl.Result{}, nil
 }
@@ -634,7 +622,7 @@ func (r *DesignateCentralReconciler) generateServiceConfigMaps(
 		},
 	}
 
-	return configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
+	return secret.EnsureSecrets(ctx, h, instance, cms, envVars)
 }
 
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart

--- a/controllers/designatemdns_controller.go
+++ b/controllers/designatemdns_controller.go
@@ -39,7 +39,6 @@ import (
 	designatemdns "github.com/openstack-k8s-operators/designate-operator/pkg/designatemdns"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/deployment"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -301,7 +300,7 @@ func (r *DesignateMdnsReconciler) reconcileNormal(ctx context.Context, instance 
 	//
 	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
 	//
-	ctrlResult, err := r.getSecret(ctx, helper, instance, instance.Spec.Secret, &configMapVars)
+	ctrlResult, err := r.getSecret(ctx, helper, instance, instance.Spec.Secret, &configMapVars, "secret-")
 	if err != nil {
 		return ctrlResult, err
 	}
@@ -310,7 +309,7 @@ func (r *DesignateMdnsReconciler) reconcileNormal(ctx context.Context, instance 
 	//
 	// check for required TransportURL secret holding transport URL string
 	//
-	ctrlResult, err = r.getSecret(ctx, helper, instance, instance.Spec.TransportURLSecret, &configMapVars)
+	ctrlResult, err = r.getSecret(ctx, helper, instance, instance.Spec.TransportURLSecret, &configMapVars, "secret-")
 	if err != nil {
 		return ctrlResult, err
 	}
@@ -320,7 +319,7 @@ func (r *DesignateMdnsReconciler) reconcileNormal(ctx context.Context, instance 
 	// check for required service secrets
 	//
 	for _, secretName := range instance.Spec.CustomServiceConfigSecrets {
-		ctrlResult, err = r.getSecret(ctx, helper, instance, secretName, &configMapVars)
+		ctrlResult, err = r.getSecret(ctx, helper, instance, secretName, &configMapVars, "secret-")
 		if err != nil {
 			return ctrlResult, err
 		}
@@ -334,29 +333,17 @@ func (r *DesignateMdnsReconciler) reconcileNormal(ctx context.Context, instance 
 	parentDesignateName := designate.GetOwningDesignateName(instance)
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' init: parent name: %s", instance.Name, parentDesignateName))
 
-	configMaps := []string{
-		fmt.Sprintf("%s-scripts", parentDesignateName),     // ScriptsConfigMap
-		fmt.Sprintf("%s-config-data", parentDesignateName), // ConfigMap
+	ctrlResult, err = r.getSecret(ctx, helper, instance, fmt.Sprintf("%s-scripts", parentDesignateName), &configMapVars, "")
+	if err != nil {
+		return ctrlResult, err
+	}
+	ctrlResult, err = r.getSecret(ctx, helper, instance, fmt.Sprintf("%s-config-data", parentDesignateName), &configMapVars, "")
+	// note r.getSecret adds Conditions with condition.InputReadyWaitingMessage
+	// when secret is not found
+	if err != nil {
+		return ctrlResult, err
 	}
 
-	_, err = configmap.GetConfigMaps(ctx, helper, instance, configMaps, instance.Namespace, &configMapVars)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
-				condition.InputReadyWaitingMessage))
-			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("Could not find all config maps for parent Designate CR %s", parentDesignateName)
-		}
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 	// run check parent Designate CR config maps - end
 
@@ -566,6 +553,7 @@ func (r *DesignateMdnsReconciler) getSecret(
 	instance *designatev1beta1.DesignateMdns,
 	secretName string,
 	envVars *map[string]env.Setter,
+	prefix string,
 ) (ctrl.Result, error) {
 	secret, hash, err := secret.GetSecret(ctx, h, secretName, instance.Namespace)
 	if err != nil {
@@ -588,7 +576,7 @@ func (r *DesignateMdnsReconciler) getSecret(
 
 	// Add a prefix to the var name to avoid accidental collision with other non-secret
 	// vars. The secret names themselves will be unique.
-	(*envVars)["secret-"+secret.Name] = env.SetValue(hash)
+	(*envVars)[prefix+secret.Name] = env.SetValue(hash)
 
 	return ctrl.Result{}, nil
 }
@@ -632,7 +620,7 @@ func (r *DesignateMdnsReconciler) generateServiceConfigMaps(
 		},
 	}
 
-	return configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
+	return secret.EnsureSecrets(ctx, h, instance, cms, envVars)
 }
 
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart

--- a/controllers/designateproducer_controller.go
+++ b/controllers/designateproducer_controller.go
@@ -40,7 +40,6 @@ import (
 	designateproducer "github.com/openstack-k8s-operators/designate-operator/pkg/designateproducer"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/deployment"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -303,7 +302,7 @@ func (r *DesignateProducerReconciler) reconcileNormal(ctx context.Context, insta
 	//
 	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
 	//
-	ctrlResult, err := r.getSecret(ctx, helper, instance, instance.Spec.Secret, &configMapVars)
+	ctrlResult, err := r.getSecret(ctx, helper, instance, instance.Spec.Secret, &configMapVars, "secret-")
 	if err != nil {
 		return ctrlResult, err
 	}
@@ -312,7 +311,7 @@ func (r *DesignateProducerReconciler) reconcileNormal(ctx context.Context, insta
 	//
 	// check for required TransportURL secret holding transport URL string
 	//
-	ctrlResult, err = r.getSecret(ctx, helper, instance, instance.Spec.TransportURLSecret, &configMapVars)
+	ctrlResult, err = r.getSecret(ctx, helper, instance, instance.Spec.TransportURLSecret, &configMapVars, "secret-")
 	if err != nil {
 		return ctrlResult, err
 	}
@@ -322,7 +321,7 @@ func (r *DesignateProducerReconciler) reconcileNormal(ctx context.Context, insta
 	// check for required service secrets
 	//
 	for _, secretName := range instance.Spec.CustomServiceConfigSecrets {
-		ctrlResult, err = r.getSecret(ctx, helper, instance, secretName, &configMapVars)
+		ctrlResult, err = r.getSecret(ctx, helper, instance, secretName, &configMapVars, "secret-")
 		if err != nil {
 			return ctrlResult, err
 		}
@@ -336,29 +335,17 @@ func (r *DesignateProducerReconciler) reconcileNormal(ctx context.Context, insta
 	parentDesignateName := designate.GetOwningDesignateName(instance)
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' init: parent name: %s", instance.Name, parentDesignateName))
 
-	configMaps := []string{
-		fmt.Sprintf("%s-scripts", parentDesignateName),     // ScriptsConfigMap
-		fmt.Sprintf("%s-config-data", parentDesignateName), // ConfigMap
+	ctrlResult, err = r.getSecret(ctx, helper, instance, fmt.Sprintf("%s-scripts", parentDesignateName), &configMapVars, "")
+	if err != nil {
+		return ctrlResult, err
+	}
+	ctrlResult, err = r.getSecret(ctx, helper, instance, fmt.Sprintf("%s-config-data", parentDesignateName), &configMapVars, "")
+	// note r.getSecret adds Conditions with condition.InputReadyWaitingMessage
+	// when secret is not found
+	if err != nil {
+		return ctrlResult, err
 	}
 
-	_, err = configmap.GetConfigMaps(ctx, helper, instance, configMaps, instance.Namespace, &configMapVars)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
-				condition.InputReadyWaitingMessage))
-			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("Could not find all config maps for parent Designate CR %s", parentDesignateName)
-		}
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 	// run check parent Designate CR config maps - end
 
@@ -568,6 +555,7 @@ func (r *DesignateProducerReconciler) getSecret(
 	instance *designatev1beta1.DesignateProducer,
 	secretName string,
 	envVars *map[string]env.Setter,
+	prefix string,
 ) (ctrl.Result, error) {
 	secret, hash, err := secret.GetSecret(ctx, h, secretName, instance.Namespace)
 	if err != nil {
@@ -590,7 +578,7 @@ func (r *DesignateProducerReconciler) getSecret(
 
 	// Add a prefix to the var name to avoid accidental collision with other non-secret
 	// vars. The secret names themselves will be unique.
-	(*envVars)["secret-"+secret.Name] = env.SetValue(hash)
+	(*envVars)[prefix+secret.Name] = env.SetValue(hash)
 
 	return ctrl.Result{}, nil
 }
@@ -634,7 +622,7 @@ func (r *DesignateProducerReconciler) generateServiceConfigMaps(
 		},
 	}
 
-	return configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
+	return secret.EnsureSecrets(ctx, h, instance, cms, envVars)
 }
 
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart

--- a/controllers/designateunbound_controller.go
+++ b/controllers/designateunbound_controller.go
@@ -35,12 +35,12 @@ import (
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/deployment"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/labels"
 	nad "github.com/openstack-k8s-operators/lib-common/modules/common/networkattachment"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/secret"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/service"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 )
@@ -422,7 +422,7 @@ func (r *UnboundReconciler) generateServiceConfigMaps(
 			Labels:        cmLabels,
 		},
 	}
-	err := configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
+	err := secret.EnsureSecrets(ctx, h, instance, cms, envVars)
 
 	if err != nil {
 		r.Log.Error(err, "uanble to process config map")

--- a/controllers/designateworker_controller.go
+++ b/controllers/designateworker_controller.go
@@ -39,7 +39,6 @@ import (
 	designateworker "github.com/openstack-k8s-operators/designate-operator/pkg/designateworker"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
-	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/deployment"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -298,7 +297,7 @@ func (r *DesignateWorkerReconciler) reconcileNormal(ctx context.Context, instanc
 	//
 	// check for required OpenStack secret holding passwords for service/admin user and add hash to the vars map
 	//
-	ctrlResult, err := r.getSecret(ctx, helper, instance, instance.Spec.Secret, &configMapVars)
+	ctrlResult, err := r.getSecret(ctx, helper, instance, instance.Spec.Secret, &configMapVars, "secret-")
 	if err != nil {
 		return ctrlResult, err
 	}
@@ -307,7 +306,7 @@ func (r *DesignateWorkerReconciler) reconcileNormal(ctx context.Context, instanc
 	//
 	// check for required TransportURL secret holding transport URL string
 	//
-	ctrlResult, err = r.getSecret(ctx, helper, instance, instance.Spec.TransportURLSecret, &configMapVars)
+	ctrlResult, err = r.getSecret(ctx, helper, instance, instance.Spec.TransportURLSecret, &configMapVars, "secret-")
 	if err != nil {
 		return ctrlResult, err
 	}
@@ -317,7 +316,7 @@ func (r *DesignateWorkerReconciler) reconcileNormal(ctx context.Context, instanc
 	// check for required service secrets
 	//
 	for _, secretName := range instance.Spec.CustomServiceConfigSecrets {
-		ctrlResult, err = r.getSecret(ctx, helper, instance, secretName, &configMapVars)
+		ctrlResult, err = r.getSecret(ctx, helper, instance, secretName, &configMapVars, "secret-")
 		if err != nil {
 			return ctrlResult, err
 		}
@@ -331,29 +330,17 @@ func (r *DesignateWorkerReconciler) reconcileNormal(ctx context.Context, instanc
 	parentDesignateName := designate.GetOwningDesignateName(instance)
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' init: parent name: %s", instance.Name, parentDesignateName))
 
-	configMaps := []string{
-		fmt.Sprintf("%s-scripts", parentDesignateName),     // ScriptsConfigMap
-		fmt.Sprintf("%s-config-data", parentDesignateName), // ConfigMap
+	ctrlResult, err = r.getSecret(ctx, helper, instance, fmt.Sprintf("%s-scripts", parentDesignateName), &configMapVars, "")
+	if err != nil {
+		return ctrlResult, err
+	}
+	ctrlResult, err = r.getSecret(ctx, helper, instance, fmt.Sprintf("%s-config-data", parentDesignateName), &configMapVars, "")
+	// note r.getSecret adds Conditions with condition.InputReadyWaitingMessage
+	// when secret is not found
+	if err != nil {
+		return ctrlResult, err
 	}
 
-	_, err = configmap.GetConfigMaps(ctx, helper, instance, configMaps, instance.Namespace, &configMapVars)
-	if err != nil {
-		if k8s_errors.IsNotFound(err) {
-			instance.Status.Conditions.Set(condition.FalseCondition(
-				condition.InputReadyCondition,
-				condition.RequestedReason,
-				condition.SeverityInfo,
-				condition.InputReadyWaitingMessage))
-			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, fmt.Errorf("Could not find all config maps for parent Designate CR %s", parentDesignateName)
-		}
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.InputReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.InputReadyErrorMessage,
-			err.Error()))
-		return ctrl.Result{}, err
-	}
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 	// run check parent Designate CR config maps - end
 
@@ -561,6 +548,7 @@ func (r *DesignateWorkerReconciler) getSecret(
 	instance *designatev1beta1.DesignateWorker,
 	secretName string,
 	envVars *map[string]env.Setter,
+	prefix string,
 ) (ctrl.Result, error) {
 	secret, hash, err := secret.GetSecret(ctx, h, secretName, instance.Namespace)
 	if err != nil {
@@ -583,7 +571,7 @@ func (r *DesignateWorkerReconciler) getSecret(
 
 	// Add a prefix to the var name to avoid accidental collision with other non-secret
 	// vars. The secret names themselves will be unique.
-	(*envVars)["secret-"+secret.Name] = env.SetValue(hash)
+	(*envVars)[prefix+secret.Name] = env.SetValue(hash)
 
 	return ctrl.Result{}, nil
 }
@@ -627,7 +615,7 @@ func (r *DesignateWorkerReconciler) generateServiceConfigMaps(
 		},
 	}
 
-	return configmap.EnsureConfigMaps(ctx, h, instance, cms, envVars)
+	return secret.EnsureSecrets(ctx, h, instance, cms, envVars)
 }
 
 // createHashOfInputHashes - creates a hash of hashes which gets added to the resources which requires a restart

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,13 @@ go 1.20
 require (
 	github.com/go-logr/logr v1.4.1
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.4.0
-	github.com/onsi/ginkgo/v2 v2.14.0
-	github.com/onsi/gomega v1.30.0
+	github.com/onsi/ginkgo/v2 v2.15.0
+	github.com/onsi/gomega v1.31.1
 	github.com/openstack-k8s-operators/designate-operator/api v0.0.0-00010101000000-000000000000
 	github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240219072823-a587b364203f
 	github.com/openstack-k8s-operators/keystone-operator/api v0.3.1-0.20240219094943-9bbb46c9afba
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.3.1-0.20240216173409-86913e6d5885
-	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240219072536-62f6b4dc7798
+	github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3
 	k8s.io/api v0.28.3
 	k8s.io/apimachinery v0.28.3
 	k8s.io/client-go v0.28.3

--- a/go.sum
+++ b/go.sum
@@ -85,10 +85,10 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY=
-github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
-github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
-github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/onsi/ginkgo/v2 v2.15.0 h1:79HwNRBAZHOEwrczrgSOPy+eFTTlIGELKy5as+ClttY=
+github.com/onsi/ginkgo/v2 v2.15.0/go.mod h1:HlxMHtYF57y6Dpf+mc5529KKmSq9h2FpCF+/ZkwUxKM=
+github.com/onsi/gomega v1.31.1 h1:KYppCUK+bUgAZwHOu7EXVBKyQA6ILvOESHkn/tgoqvo=
+github.com/onsi/gomega v1.31.1/go.mod h1:y40C95dwAD1Nz36SsEnxvfFe8FFfNxzI5eJ0EYGyAy0=
 github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7 h1:rncLxJBpFGqBztyxCMwNRnMjhhIDOWHJowi6q8G6koI=
 github.com/openshift/api v0.0.0-20230414143018-3367bc7e6ac7/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openstack-k8s-operators/infra-operator/apis v0.3.1-0.20240219072823-a587b364203f h1:suf/08227pC+qQRbsUPLMOSw3mJ82b0o9Hs7MO/g9BY=
@@ -101,8 +101,8 @@ github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.2024021
 github.com/openstack-k8s-operators/lib-common/modules/openstack v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:8QsCFttAm+X6A8I8EQThGjNjeMAYt2hK7ivbvnR3434=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240216173409-86913e6d5885 h1:sMO+IYsZ91Nho0FV6y03J0NTGd8+ZWB4KmKJJU94gTU=
 github.com/openstack-k8s-operators/lib-common/modules/storage v0.3.1-0.20240216173409-86913e6d5885/go.mod h1:sK82mkh2UzITsbNa/y6AKTZftHQnsYigqRx+rFbfZM4=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240219072536-62f6b4dc7798 h1:zL4DdQ5HPXCLHeRMAWC2zI7ypbkZVYg3UkyEFSnzeow=
-github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240219072536-62f6b4dc7798/go.mod h1:PDqfLbP4ZWqQHAu1OtbjfpOGQUKSzLqRJChvE/9pcyQ=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3 h1:fwb+GvvnN9Mhkgg5pBksZ8W5+hLCcNOorHsUTQYA1Lg=
+github.com/openstack-k8s-operators/mariadb-operator/api v0.3.1-0.20240303091826-438dde8600d3/go.mod h1:f9IIyWeoskWoeWaDFF3qmAJ2Kqyovfi0Ar/QUfk3qag=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/designate/dbsync.go
+++ b/pkg/designate/dbsync.go
@@ -78,10 +78,8 @@ func DbSyncJob(
 	initContainerDetails := APIDetails{
 		ContainerImage:       instance.Spec.DesignateAPI.ContainerImage,
 		DatabaseHost:         instance.Status.DatabaseHostname,
-		DatabaseUser:         instance.Spec.DatabaseUser,
 		DatabaseName:         DatabaseName,
 		OSPSecret:            instance.Spec.Secret,
-		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
 		VolumeMounts:         initVolumeMounts,
 	}

--- a/pkg/designate/initcontainer.go
+++ b/pkg/designate/initcontainer.go
@@ -25,11 +25,9 @@ import (
 type APIDetails struct {
 	ContainerImage       string
 	DatabaseHost         string
-	DatabaseUser         string
 	DatabaseName         string
 	OSPSecret            string
 	TransportURLSecret   string
-	DBPasswordSelector   string
 	UserPasswordSelector string
 	BackendType          string
 	VolumeMounts         []corev1.VolumeMount
@@ -52,22 +50,10 @@ func InitContainer(init APIDetails) []corev1.Container {
 
 	envVars := map[string]env.Setter{}
 	envVars["DatabaseHost"] = env.SetValue(init.DatabaseHost)
-	envVars["DatabaseUser"] = env.SetValue(init.DatabaseUser)
 	envVars["DatabaseName"] = env.SetValue(init.DatabaseName)
 	envVars["BackendType"] = env.SetValue(init.BackendType)
 
 	envs := []corev1.EnvVar{
-		{
-			Name: "DatabasePassword",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: init.OSPSecret,
-					},
-					Key: init.DBPasswordSelector,
-				},
-			},
-		},
 		{
 			Name: "AdminPassword",
 			ValueFrom: &corev1.EnvVarSource{

--- a/pkg/designate/volumes.go
+++ b/pkg/designate/volumes.go
@@ -36,22 +36,18 @@ func GetVolumes(baseConfigMapName string) []corev1.Volume {
 		{
 			Name: scriptVolume,
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &scriptMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: baseConfigMapName + "-scripts",
-					},
+					SecretName:  baseConfigMapName + "-scripts",
 				},
 			},
 		},
 		{
 			Name: configVolume,
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &configMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: baseConfigMapName + "-config-data",
-					},
+					SecretName:  baseConfigMapName + "-config-data",
 				},
 			},
 		},
@@ -118,22 +114,18 @@ func getVolumes(name string) []corev1.Volume {
 		{
 			Name: "scripts",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &scriptsVolumeDefaultMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: name + "-scripts",
-					},
+					SecretName:  name + "-scripts",
 				},
 			},
 		},
 		{
 			Name: "config-data",
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &config0640AccessMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: name + "-config-data",
-					},
+					SecretName:  name + "-config-data",
 				},
 			},
 		},

--- a/pkg/designateapi/deployment.go
+++ b/pkg/designateapi/deployment.go
@@ -129,11 +129,9 @@ func Deployment(
 	initContainerDetails := designate.APIDetails{
 		ContainerImage:       instance.Spec.ContainerImage,
 		DatabaseHost:         instance.Spec.DatabaseHostname,
-		DatabaseUser:         instance.Spec.DatabaseUser,
 		DatabaseName:         designate.DatabaseName,
 		OSPSecret:            instance.Spec.Secret,
 		TransportURLSecret:   instance.Spec.TransportURLSecret,
-		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
 		VolumeMounts:         designate.GetInitVolumeMounts(),
 	}

--- a/pkg/designatebackendbind9/deployment.go
+++ b/pkg/designatebackendbind9/deployment.go
@@ -163,11 +163,9 @@ func Deployment(
 	initContainerDetails := designate.APIDetails{
 		ContainerImage:       instance.Spec.ContainerImage,
 		DatabaseHost:         instance.Spec.DatabaseHostname,
-		DatabaseUser:         instance.Spec.DatabaseUser,
 		DatabaseName:         designate.DatabaseName,
 		OSPSecret:            instance.Spec.Secret,
 		TransportURLSecret:   instance.Spec.TransportURLSecret,
-		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
 		VolumeMounts:         designate.GetInitVolumeMounts(),
 	}

--- a/pkg/designatecentral/deployment.go
+++ b/pkg/designatecentral/deployment.go
@@ -132,11 +132,9 @@ func Deployment(
 	initContainerDetails := designate.APIDetails{
 		ContainerImage:       instance.Spec.ContainerImage,
 		DatabaseHost:         instance.Spec.DatabaseHostname,
-		DatabaseUser:         instance.Spec.DatabaseUser,
 		DatabaseName:         designate.DatabaseName,
 		OSPSecret:            instance.Spec.Secret,
 		TransportURLSecret:   instance.Spec.TransportURLSecret,
-		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
 		VolumeMounts:         designate.GetInitVolumeMounts(),
 	}

--- a/pkg/designatemdns/deployment.go
+++ b/pkg/designatemdns/deployment.go
@@ -129,11 +129,9 @@ func Deployment(
 	initContainerDetails := designate.APIDetails{
 		ContainerImage:       instance.Spec.ContainerImage,
 		DatabaseHost:         instance.Spec.DatabaseHostname,
-		DatabaseUser:         instance.Spec.DatabaseUser,
 		DatabaseName:         designate.DatabaseName,
 		OSPSecret:            instance.Spec.Secret,
 		TransportURLSecret:   instance.Spec.TransportURLSecret,
-		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
 		VolumeMounts:         designate.GetInitVolumeMounts(),
 	}

--- a/pkg/designateproducer/deployment.go
+++ b/pkg/designateproducer/deployment.go
@@ -128,11 +128,9 @@ func Deployment(
 	initContainerDetails := designate.APIDetails{
 		ContainerImage:       instance.Spec.ContainerImage,
 		DatabaseHost:         instance.Spec.DatabaseHostname,
-		DatabaseUser:         instance.Spec.DatabaseUser,
 		DatabaseName:         designate.DatabaseName,
 		OSPSecret:            instance.Spec.Secret,
 		TransportURLSecret:   instance.Spec.TransportURLSecret,
-		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
 		VolumeMounts:         designate.GetInitVolumeMounts(),
 	}

--- a/pkg/designateunbound/deployment.go
+++ b/pkg/designateunbound/deployment.go
@@ -44,11 +44,9 @@ func Deployment(instance *designatev1beta1.DesignateUnbound,
 		{
 			Name: configVolume,
 			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
+				Secret: &corev1.SecretVolumeSource{
 					DefaultMode: &configMode,
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "designate-unbound-config-data",
-					},
+					SecretName:  "designate-unbound-config-data",
 				},
 			},
 		},

--- a/pkg/designateworker/deployment.go
+++ b/pkg/designateworker/deployment.go
@@ -128,11 +128,9 @@ func Deployment(
 	initContainerDetails := designate.APIDetails{
 		ContainerImage:       instance.Spec.ContainerImage,
 		DatabaseHost:         instance.Spec.DatabaseHostname,
-		DatabaseUser:         instance.Spec.DatabaseUser,
 		DatabaseName:         designate.DatabaseName,
 		OSPSecret:            instance.Spec.Secret,
 		TransportURLSecret:   instance.Spec.TransportURLSecret,
-		DBPasswordSelector:   instance.Spec.PasswordSelectors.Database,
 		UserPasswordSelector: instance.Spec.PasswordSelectors.Service,
 		VolumeMounts:         designate.GetInitVolumeMounts(),
 	}

--- a/templates/designate/bin/init.sh
+++ b/templates/designate/bin/init.sh
@@ -20,10 +20,6 @@ set -ex
 #
 # Secrets are obtained from ENV variables.
 export PASSWORD=${AdminPassword:?"Please specify a AdminPassword variable."}
-export DBHOST=${DatabaseHost:?"Please specify a DatabaseHost variable."}
-export DBUSER=${DatabaseUser:?"Please specify a DatabaseUser variable."}
-export DBPASSWORD=${DatabasePassword:?"Please specify a DatabasePassword variable."}
-export DB=${DatabaseName:-"designate"}
 export TRANSPORTURL=${TransportURL:-""}
 export BACKENDURL=${BackendURL:-"redis://redis:6379/"}
 export BACKENDTYPE=${BackendType:-"None"}
@@ -94,8 +90,6 @@ for dir in /var/lib/config-data/default; do
 done
 
 # set secrets in the config-data
-crudini --set ${SVC_CFG_MERGED} database connection mysql+pymysql://${DBUSER}:${DBPASSWORD}@${DBHOST}/${DB}
-crudini --set ${SVC_CFG_MERGED} storage:sqlalchemy connection mysql+pymysql://root:${DBPASSWORD}@${DBHOST}/${DB}?charset=utf8
 crudini --set ${SVC_CFG_MERGED} keystone_authtoken password $PASSWORD
 if [ -n "$TRANSPORTURL" ]; then
     crudini --set ${SVC_CFG_MERGED} DEFAULT transport_url $TRANSPORTURL

--- a/templates/designate/config/designate.conf
+++ b/templates/designate/config/designate.conf
@@ -17,13 +17,14 @@ transport_url=rabbit://stackrabbit:secret@10.0.110.9:5672/
 healthcheck_enabled=True
 
 [database]
-connection = mysql+pymysql://${DBUSER}:${DBPASSWORD}@${DBHOST}/${DB}
+connection={{ .DatabaseConnection }}
 
 [storage:sqlalchemy]
-connection = mysql+pymysql://root:${DBPASSWORD}@${DBHOST}/${DB}?charset=utf8
+connection={{ .DatabaseConnection }}
 
 [coordination]
 backend_url=memcached://127.0.0.1:11211
+
 
 [service:api]
 quotas_verify_project_id=True

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: designate
 spec:
   databaseInstance: openstack
-  databaseUser: designate
+  databaseAccount: designate
   serviceUser: designate
   secret: osp-secret
   preserveJobs: false

--- a/tests/kuttl/tests/basic/deploy/designate_v1beta1_designate.yaml
+++ b/tests/kuttl/tests/basic/deploy/designate_v1beta1_designate.yaml
@@ -10,7 +10,7 @@ spec:
     [DEFAULT]
     debug = true
   databaseInstance: openstack
-  databaseUser: designate
+  databaseAccount: designate
   rabbitMqClusterName: rabbitmq
   designateAPI:
     replicas: 1


### PR DESCRIPTION
This moves designate to fully use MariaDBAccount based on the dev work being done for mariadb-operator:

Lead Jira: [OSPRH-4095](https://issues.redhat.com/browse/OSPRH-4095)

1. [x] controller calls EnsureMariaDBAccount up front to make sure MariaDBAccount is present
2. [x] error code from EnsureMariaDBAccount is handled, Conditions are amended when error is returned
3. [x] controller calls NewDatabaseForAccount instead of NewDatabase
4. [x]  GetAccountAndSecret is used to retrieve account /secret to populate template
5. [x]  GetDatabaseByName() , normally used for delete finalizers, replaced with GetDatabaseByNameAndAccount
6. [x]  CreateOrPatchAll() used to patch the Database, replacing CreateOrPatchDB / CreateOrPatchDBByName
7. [x]  controller calls DeleteUnusedMariaDBAccountFinalizers when launched pods are definitely running on a new MariaDBAccount, returns error code if present
8. [x]  PasswordSelectors that refer to database are removed
9. [x]  all databaseUser replaced with databaseAccount inside of all XYZ_types.go
10. [x] all databaseUser replaced with databaseAccount inside of all `kuttl/*.yaml`
11. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all XYZ_types.go
12. [x] all default databaseUser names become databaseAccount, replacing underscores with dashes inside of all `kuttl/*.yaml`
13. [ ] ~~MariaDBAccountSuiteTests are used in controller ginkgo tests if it has them~~ N/A , no ginkgo suite
14. [x] Use configsecrets for database URLs; remove from job hash
15. [x] [184](https://github.com/openstack-k8s-operators/mariadb-operator/pull/184) is merged and replaces from go.mod are removed

