### PR TITLE
Ensure golangci-lint runs on all files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,5 +59,5 @@ repos:
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.55.2
   hooks:
-    - id: golangci-lint
+    - id: golangci-lint-full
       args: ["-v"]

--- a/controllers/designate_controller.go
+++ b/controllers/designate_controller.go
@@ -393,7 +393,7 @@ func (r *DesignateReconciler) reconcileInit(
 	// run Designate db sync
 	//
 	dbSyncHash := instance.Status.Hash[designatev1beta1.DbSyncHash]
-	jobDef := designate.DbSyncJob(instance, serviceLabels)
+	jobDef := designate.DbSyncJob(instance, serviceLabels, serviceAnnotations)
 
 	dbSyncjob := job.NewJob(
 		jobDef,

--- a/controllers/designate_controller.go
+++ b/controllers/designate_controller.go
@@ -649,7 +649,7 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 	}
 
 	// Handle service update
-	ctrlResult, err = r.reconcileUpdate(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpdate(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -657,7 +657,7 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 	}
 
 	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpgrade(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -859,7 +859,7 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 	return ctrl.Result{}, nil
 }
 
-func (r *DesignateReconciler) reconcileUpdate(ctx context.Context, instance *designatev1beta1.Designate, helper *helper.Helper) (ctrl.Result, error) {
+func (r *DesignateReconciler) reconcileUpdate(ctx context.Context, instance *designatev1beta1.Designate) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' update", instance.Name))
@@ -871,7 +871,7 @@ func (r *DesignateReconciler) reconcileUpdate(ctx context.Context, instance *des
 	return ctrl.Result{}, nil
 }
 
-func (r *DesignateReconciler) reconcileUpgrade(ctx context.Context, instance *designatev1beta1.Designate, helper *helper.Helper) (ctrl.Result, error) {
+func (r *DesignateReconciler) reconcileUpgrade(ctx context.Context, instance *designatev1beta1.Designate) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' upgrade", instance.Name))

--- a/controllers/designateapi_controller.go
+++ b/controllers/designateapi_controller.go
@@ -682,7 +682,7 @@ func (r *DesignateAPIReconciler) reconcileNormal(ctx context.Context, instance *
 	}
 
 	// Handle service update
-	ctrlResult, err = r.reconcileUpdate(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpdate(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -690,7 +690,7 @@ func (r *DesignateAPIReconciler) reconcileNormal(ctx context.Context, instance *
 	}
 
 	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpgrade(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -775,7 +775,7 @@ func (r *DesignateAPIReconciler) reconcileNormal(ctx context.Context, instance *
 	return ctrl.Result{}, nil
 }
 
-func (r *DesignateAPIReconciler) reconcileUpdate(ctx context.Context, instance *designatev1beta1.DesignateAPI, helper *helper.Helper) (ctrl.Result, error) {
+func (r *DesignateAPIReconciler) reconcileUpdate(ctx context.Context, instance *designatev1beta1.DesignateAPI) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' update", instance.Name))
@@ -787,7 +787,7 @@ func (r *DesignateAPIReconciler) reconcileUpdate(ctx context.Context, instance *
 	return ctrl.Result{}, nil
 }
 
-func (r *DesignateAPIReconciler) reconcileUpgrade(ctx context.Context, instance *designatev1beta1.DesignateAPI, helper *helper.Helper) (ctrl.Result, error) {
+func (r *DesignateAPIReconciler) reconcileUpgrade(ctx context.Context, instance *designatev1beta1.DesignateAPI) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' upgrade", instance.Name))

--- a/controllers/designatebackendbind9_controller.go
+++ b/controllers/designatebackendbind9_controller.go
@@ -173,7 +173,7 @@ func (r *DesignateBackendbind9Reconciler) Reconcile(ctx context.Context, req ctr
 
 	// Handle service delete
 	if !instance.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, instance, helper)
+		return r.reconcileDelete(instance, helper)
 	}
 
 	// Handle non-deleted clusters
@@ -320,7 +320,7 @@ func (r *DesignateBackendbind9Reconciler) SetupWithManager(mgr ctrl.Manager) err
 		Complete(r)
 }
 
-func (r *DesignateBackendbind9Reconciler) reconcileDelete(ctx context.Context, instance *designatev1beta1.DesignateBackendbind9, helper *helper.Helper) (ctrl.Result, error) {
+func (r *DesignateBackendbind9Reconciler) reconcileDelete(instance *designatev1beta1.DesignateBackendbind9, helper *helper.Helper) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling Service '%s' delete", instance.Name))
 
 	// We did all the cleanup on the objects we created so we can remove the
@@ -332,10 +332,7 @@ func (r *DesignateBackendbind9Reconciler) reconcileDelete(ctx context.Context, i
 }
 
 func (r *DesignateBackendbind9Reconciler) reconcileInit(
-	ctx context.Context,
 	instance *designatev1beta1.DesignateBackendbind9,
-	helper *helper.Helper,
-	serviceLabels map[string]string,
 ) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling Service '%s' init", instance.Name))
 
@@ -427,7 +424,7 @@ func (r *DesignateBackendbind9Reconciler) reconcileNormal(ctx context.Context, i
 	// create hash over all the different input resources to identify if any those changed
 	// and a restart/recreate is required.
 	//
-	inputHash, hashChanged, err := r.createHashOfInputHashes(ctx, instance, configMapVars)
+	inputHash, hashChanged, err := r.createHashOfInputHashes(instance, configMapVars)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ServiceConfigReadyCondition,
@@ -479,7 +476,7 @@ func (r *DesignateBackendbind9Reconciler) reconcileNormal(ctx context.Context, i
 	}
 
 	// Handle service init
-	ctrlResult, err = r.reconcileInit(ctx, instance, helper, serviceLabels)
+	ctrlResult, err = r.reconcileInit(instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -487,7 +484,7 @@ func (r *DesignateBackendbind9Reconciler) reconcileNormal(ctx context.Context, i
 	}
 
 	// Handle service update
-	ctrlResult, err = r.reconcileUpdate(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpdate(instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -495,7 +492,7 @@ func (r *DesignateBackendbind9Reconciler) reconcileNormal(ctx context.Context, i
 	}
 
 	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpgrade(instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -580,7 +577,7 @@ func (r *DesignateBackendbind9Reconciler) reconcileNormal(ctx context.Context, i
 	return ctrl.Result{}, nil
 }
 
-func (r *DesignateBackendbind9Reconciler) reconcileUpdate(ctx context.Context, instance *designatev1beta1.DesignateBackendbind9, helper *helper.Helper) (ctrl.Result, error) {
+func (r *DesignateBackendbind9Reconciler) reconcileUpdate(instance *designatev1beta1.DesignateBackendbind9) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling Service '%s' update", instance.Name))
 
 	// TODO: should have minor update tasks if required
@@ -590,7 +587,7 @@ func (r *DesignateBackendbind9Reconciler) reconcileUpdate(ctx context.Context, i
 	return ctrl.Result{}, nil
 }
 
-func (r *DesignateBackendbind9Reconciler) reconcileUpgrade(ctx context.Context, instance *designatev1beta1.DesignateBackendbind9, helper *helper.Helper) (ctrl.Result, error) {
+func (r *DesignateBackendbind9Reconciler) reconcileUpgrade(instance *designatev1beta1.DesignateBackendbind9) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling Service '%s' upgrade", instance.Name))
 
 	// TODO: should have major version upgrade tasks
@@ -682,7 +679,6 @@ func (r *DesignateBackendbind9Reconciler) generateServiceConfigMaps(
 //
 // returns the hash, whether the hash changed (as a bool) and any error
 func (r *DesignateBackendbind9Reconciler) createHashOfInputHashes(
-	ctx context.Context,
 	instance *designatev1beta1.DesignateBackendbind9,
 	envVars map[string]env.Setter,
 ) (string, bool, error) {

--- a/controllers/designatecentral_controller.go
+++ b/controllers/designatecentral_controller.go
@@ -288,8 +288,6 @@ func (r *DesignateCentralReconciler) reconcileDelete(ctx context.Context, instan
 func (r *DesignateCentralReconciler) reconcileInit(
 	ctx context.Context,
 	instance *designatev1beta1.DesignateCentral,
-	helper *helper.Helper,
-	serviceLabels map[string]string,
 ) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
@@ -437,7 +435,7 @@ func (r *DesignateCentralReconciler) reconcileNormal(ctx context.Context, instan
 	}
 
 	// Handle service init
-	ctrlResult, err = r.reconcileInit(ctx, instance, helper, serviceLabels)
+	ctrlResult, err = r.reconcileInit(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -445,7 +443,7 @@ func (r *DesignateCentralReconciler) reconcileNormal(ctx context.Context, instan
 	}
 
 	// Handle service update
-	ctrlResult, err = r.reconcileUpdate(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpdate(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -453,7 +451,7 @@ func (r *DesignateCentralReconciler) reconcileNormal(ctx context.Context, instan
 	}
 
 	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpgrade(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -538,7 +536,7 @@ func (r *DesignateCentralReconciler) reconcileNormal(ctx context.Context, instan
 	return ctrl.Result{}, nil
 }
 
-func (r *DesignateCentralReconciler) reconcileUpdate(ctx context.Context, instance *designatev1beta1.DesignateCentral, helper *helper.Helper) (ctrl.Result, error) {
+func (r *DesignateCentralReconciler) reconcileUpdate(ctx context.Context, instance *designatev1beta1.DesignateCentral) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' update", instance.Name))
@@ -550,7 +548,7 @@ func (r *DesignateCentralReconciler) reconcileUpdate(ctx context.Context, instan
 	return ctrl.Result{}, nil
 }
 
-func (r *DesignateCentralReconciler) reconcileUpgrade(ctx context.Context, instance *designatev1beta1.DesignateCentral, helper *helper.Helper) (ctrl.Result, error) {
+func (r *DesignateCentralReconciler) reconcileUpgrade(ctx context.Context, instance *designatev1beta1.DesignateCentral) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' upgrade", instance.Name))

--- a/controllers/designatemdns_controller.go
+++ b/controllers/designatemdns_controller.go
@@ -286,8 +286,6 @@ func (r *DesignateMdnsReconciler) reconcileDelete(ctx context.Context, instance 
 func (r *DesignateMdnsReconciler) reconcileInit(
 	ctx context.Context,
 	instance *designatev1beta1.DesignateMdns,
-	helper *helper.Helper,
-	serviceLabels map[string]string,
 ) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
@@ -435,7 +433,7 @@ func (r *DesignateMdnsReconciler) reconcileNormal(ctx context.Context, instance 
 	}
 
 	// Handle service init
-	ctrlResult, err = r.reconcileInit(ctx, instance, helper, serviceLabels)
+	ctrlResult, err = r.reconcileInit(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -443,7 +441,7 @@ func (r *DesignateMdnsReconciler) reconcileNormal(ctx context.Context, instance 
 	}
 
 	// Handle service update
-	ctrlResult, err = r.reconcileUpdate(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpdate(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -451,7 +449,7 @@ func (r *DesignateMdnsReconciler) reconcileNormal(ctx context.Context, instance 
 	}
 
 	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpgrade(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -536,7 +534,7 @@ func (r *DesignateMdnsReconciler) reconcileNormal(ctx context.Context, instance 
 	return ctrl.Result{}, nil
 }
 
-func (r *DesignateMdnsReconciler) reconcileUpdate(ctx context.Context, instance *designatev1beta1.DesignateMdns, helper *helper.Helper) (ctrl.Result, error) {
+func (r *DesignateMdnsReconciler) reconcileUpdate(ctx context.Context, instance *designatev1beta1.DesignateMdns) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' update", instance.Name))
@@ -548,7 +546,7 @@ func (r *DesignateMdnsReconciler) reconcileUpdate(ctx context.Context, instance 
 	return ctrl.Result{}, nil
 }
 
-func (r *DesignateMdnsReconciler) reconcileUpgrade(ctx context.Context, instance *designatev1beta1.DesignateMdns, helper *helper.Helper) (ctrl.Result, error) {
+func (r *DesignateMdnsReconciler) reconcileUpgrade(ctx context.Context, instance *designatev1beta1.DesignateMdns) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' upgrade", instance.Name))

--- a/controllers/designateproducer_controller.go
+++ b/controllers/designateproducer_controller.go
@@ -288,8 +288,6 @@ func (r *DesignateProducerReconciler) reconcileDelete(ctx context.Context, insta
 func (r *DesignateProducerReconciler) reconcileInit(
 	ctx context.Context,
 	instance *designatev1beta1.DesignateProducer,
-	helper *helper.Helper,
-	serviceLabels map[string]string,
 ) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
@@ -437,7 +435,7 @@ func (r *DesignateProducerReconciler) reconcileNormal(ctx context.Context, insta
 	}
 
 	// Handle service init
-	ctrlResult, err = r.reconcileInit(ctx, instance, helper, serviceLabels)
+	ctrlResult, err = r.reconcileInit(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -445,7 +443,7 @@ func (r *DesignateProducerReconciler) reconcileNormal(ctx context.Context, insta
 	}
 
 	// Handle service update
-	ctrlResult, err = r.reconcileUpdate(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpdate(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -453,7 +451,7 @@ func (r *DesignateProducerReconciler) reconcileNormal(ctx context.Context, insta
 	}
 
 	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpgrade(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -538,7 +536,7 @@ func (r *DesignateProducerReconciler) reconcileNormal(ctx context.Context, insta
 	return ctrl.Result{}, nil
 }
 
-func (r *DesignateProducerReconciler) reconcileUpdate(ctx context.Context, instance *designatev1beta1.DesignateProducer, helper *helper.Helper) (ctrl.Result, error) {
+func (r *DesignateProducerReconciler) reconcileUpdate(ctx context.Context, instance *designatev1beta1.DesignateProducer) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' update", instance.Name))
@@ -550,7 +548,7 @@ func (r *DesignateProducerReconciler) reconcileUpdate(ctx context.Context, insta
 	return ctrl.Result{}, nil
 }
 
-func (r *DesignateProducerReconciler) reconcileUpgrade(ctx context.Context, instance *designatev1beta1.DesignateProducer, helper *helper.Helper) (ctrl.Result, error) {
+func (r *DesignateProducerReconciler) reconcileUpgrade(ctx context.Context, instance *designatev1beta1.DesignateProducer) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' upgrade", instance.Name))

--- a/controllers/designateworker_controller.go
+++ b/controllers/designateworker_controller.go
@@ -285,8 +285,6 @@ func (r *DesignateWorkerReconciler) reconcileDelete(ctx context.Context, instanc
 func (r *DesignateWorkerReconciler) reconcileInit(
 	ctx context.Context,
 	instance *designatev1beta1.DesignateWorker,
-	helper *helper.Helper,
-	serviceLabels map[string]string,
 ) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' init", instance.Name))
@@ -432,7 +430,7 @@ func (r *DesignateWorkerReconciler) reconcileNormal(ctx context.Context, instanc
 	}
 
 	// Handle service init
-	ctrlResult, err = r.reconcileInit(ctx, instance, helper, serviceLabels)
+	ctrlResult, err = r.reconcileInit(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -440,7 +438,7 @@ func (r *DesignateWorkerReconciler) reconcileNormal(ctx context.Context, instanc
 	}
 
 	// Handle service update
-	ctrlResult, err = r.reconcileUpdate(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpdate(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -448,7 +446,7 @@ func (r *DesignateWorkerReconciler) reconcileNormal(ctx context.Context, instanc
 	}
 
 	// Handle service upgrade
-	ctrlResult, err = r.reconcileUpgrade(ctx, instance, helper)
+	ctrlResult, err = r.reconcileUpgrade(ctx, instance)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -533,7 +531,7 @@ func (r *DesignateWorkerReconciler) reconcileNormal(ctx context.Context, instanc
 	return ctrl.Result{}, nil
 }
 
-func (r *DesignateWorkerReconciler) reconcileUpdate(ctx context.Context, instance *designatev1beta1.DesignateWorker, helper *helper.Helper) (ctrl.Result, error) {
+func (r *DesignateWorkerReconciler) reconcileUpdate(ctx context.Context, instance *designatev1beta1.DesignateWorker) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' update", instance.Name))
 
@@ -544,7 +542,7 @@ func (r *DesignateWorkerReconciler) reconcileUpdate(ctx context.Context, instanc
 	return ctrl.Result{}, nil
 }
 
-func (r *DesignateWorkerReconciler) reconcileUpgrade(ctx context.Context, instance *designatev1beta1.DesignateWorker, helper *helper.Helper) (ctrl.Result, error) {
+func (r *DesignateWorkerReconciler) reconcileUpgrade(ctx context.Context, instance *designatev1beta1.DesignateWorker) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' upgrade", instance.Name))
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -20,8 +20,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/api v0.28.9
 	k8s.io/apimachinery v0.28.9
 	k8s.io/client-go v0.28.9
+	k8s.io/utils v0.0.0-20240423183400-0849a56e8f22
 	sigs.k8s.io/controller-runtime v0.16.5
 )
 
@@ -75,7 +76,6 @@ require (
 	k8s.io/component-base v0.28.9 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
-	k8s.io/utils v0.0.0-20240423183400-0849a56e8f22 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/pkg/designate/dbsync.go
+++ b/pkg/designate/dbsync.go
@@ -32,6 +32,7 @@ const (
 func DbSyncJob(
 	instance *designatev1beta1.Designate,
 	labels map[string]string,
+	annotations map[string]string,
 ) *batchv1.Job {
 	runAsUser := int64(0)
 	initVolumeMounts := getInitVolumeMounts()
@@ -51,6 +52,9 @@ func DbSyncJob(
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: annotations,
+				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyOnFailure,
 					ServiceAccountName: instance.RbacResourceName(),

--- a/pkg/designateunbound/deployment.go
+++ b/pkg/designateunbound/deployment.go
@@ -25,6 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -37,7 +38,6 @@ func Deployment(instance *designatev1beta1.DesignateUnbound,
 	labels map[string]string,
 	annotations map[string]string,
 ) *appsv1.Deployment {
-	var rootUser int64 = 0
 	var configMode int32 = 0640
 
 	volumes := []corev1.Volume{
@@ -123,7 +123,7 @@ func Deployment(instance *designatev1beta1.DesignateUnbound,
 							"-p",
 						},
 						SecurityContext: &corev1.SecurityContext{
-							RunAsUser: &rootUser,
+							RunAsUser: ptr.To[int64](0),
 						},
 						Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
 						VolumeMounts:   mounts,


### PR DESCRIPTION
* removed unused func params
* ignore revive dot-imports rule on ginkgo and gomega as dot import
there is the recommended practice
* various small style fixes found by the linter
* the linter also showed that we the network attachments are unused. This was probably missed during some refactor as the network attachments was gathered but isn't passed anywhere. Based on the controller logic we can pass it to the dbsync job. 