### PR TITLE
Enable Secure RBAC

### DIFF
--- a/templates/designate/config/designate.conf
+++ b/templates/designate/config/designate.conf
@@ -57,6 +57,10 @@ driver=messagingv2
 [oslo_concurrency]
 lock_path=/opt/stack/data/designate
 
+[oslo_policy]
+enforce_scope=True
+enforce_new_defaults=True
+
 [health_manager]
 health_update_threads=4
 stats_update_threads=4


### PR DESCRIPTION
This patch enables the Secure RBAC policies to include both the Keystone default roles, and Keystone scoped tokens.

[1] https://docs.openstack.org/designate/latest/admin/policy.html#enabling-keystone-default-roles-and-scoped-tokens