### PR TITLE
Fix mdns replicas nil

### DIFF
--- a/config/manifests/bases/designate-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/designate-operator.clusterserviceversion.yaml
@@ -4,8 +4,8 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/proxy-aware: "false"
     features.operators.openshift.io/tls-profiles: "false"
     features.operators.openshift.io/token-auth-aws: "false"
@@ -34,67 +34,31 @@ spec:
       displayName: Designate API
       kind: DesignateAPI
       name: designateapis.designate.openstack.org
-      specDescriptors:
-      - description: TLS - Parameters related to the TLS
-        displayName: TLS
-        path: tls
       version: v1beta1
     - description: DesignateCentral is the Schema for the designatecentral API
       displayName: Designate Central
       kind: DesignateCentral
       name: designatecentrals.designate.openstack.org
-      specDescriptors:
-      - description: TLS - Parameters related to the TLS
-        displayName: TLS
-        path: tls
       version: v1beta1
     - description: DesignateMdns is the Schema for the designatemdnses API
       displayName: Designate Mdns
       kind: DesignateMdns
       name: designatemdnses.designate.openstack.org
-      specDescriptors:
-      - description: TLS - Parameters related to the TLS
-        displayName: TLS
-        path: tls
       version: v1beta1
     - description: DesignateProducer is the Schema for the designateproducer API
       displayName: Designate Producer
       kind: DesignateProducer
       name: designateproducers.designate.openstack.org
-      specDescriptors:
-      - description: TLS - Parameters related to the TLS
-        displayName: TLS
-        path: tls
       version: v1beta1
     - description: Designate is the Schema for the designates API
       displayName: Designate
       kind: Designate
       name: designates.designate.openstack.org
-      specDescriptors:
-      - description: TLS - Parameters related to the TLS
-        displayName: TLS
-        path: designateAPI.tls
-      - description: TLS - Parameters related to the TLS
-        displayName: TLS
-        path: designateCentral.tls
-      - description: TLS - Parameters related to the TLS
-        displayName: TLS
-        path: designateMdns.tls
-      - description: TLS - Parameters related to the TLS
-        displayName: TLS
-        path: designateProducer.tls
-      - description: TLS - Parameters related to the TLS
-        displayName: TLS
-        path: designateWorker.tls
       version: v1beta1
     - description: DesignateWorker is the Schema for the designateworker API
       displayName: Designate Worker
       kind: DesignateWorker
       name: designateworkers.designate.openstack.org
-      specDescriptors:
-      - description: TLS - Parameters related to the TLS
-        displayName: TLS
-        path: tls
       version: v1beta1
   description: Designate Operator
   displayName: Designate Operator

--- a/controllers/designatemdns_controller.go
+++ b/controllers/designatemdns_controller.go
@@ -494,7 +494,7 @@ func (r *DesignateMdnsReconciler) reconcileNormal(ctx context.Context, instance 
 		// verify if network attachment matches expectations
 		networkReady := false
 		networkAttachmentStatus := map[string][]string{}
-		if *(instance.Spec.Replicas) > 0 {
+		if instance.Spec.Replicas != nil && *(instance.Spec.Replicas) > 0 {
 			networkReady, networkAttachmentStatus, err = nad.VerifyNetworkStatusFromAnnotation(
 				ctx,
 				helper,
@@ -524,7 +524,7 @@ func (r *DesignateMdnsReconciler) reconcileNormal(ctx context.Context, instance 
 			return ctrl.Result{}, err
 		}
 
-		if instance.Status.ReadyCount == *instance.Spec.Replicas {
+		if instance.Spec.Replicas != nil && instance.Status.ReadyCount == *instance.Spec.Replicas {
 			instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
 		}
 	}


### PR DESCRIPTION
Designate Mdns panicked after trying to access addresses in a few lines where it got nil pointer.

This patch fixes it by making sure the address it not nil.