### PR TITLE
Remove backendtype uses

### DIFF
--- a/pkg/designate/initcontainer.go
+++ b/pkg/designate/initcontainer.go
@@ -29,7 +29,6 @@ type APIDetails struct {
 	OSPSecret            string
 	TransportURLSecret   string
 	UserPasswordSelector string
-	BackendType          string
 	VolumeMounts         []corev1.VolumeMount
 	Privileged           bool
 }
@@ -51,7 +50,6 @@ func InitContainer(init APIDetails) []corev1.Container {
 	envVars := map[string]env.Setter{}
 	envVars["DatabaseHost"] = env.SetValue(init.DatabaseHost)
 	envVars["DatabaseName"] = env.SetValue(init.DatabaseName)
-	envVars["BackendType"] = env.SetValue(init.BackendType)
 
 	envs := []corev1.EnvVar{
 		{

--- a/templates/designate/bin/init.sh
+++ b/templates/designate/bin/init.sh
@@ -22,7 +22,6 @@ set -ex
 export PASSWORD=${AdminPassword:?"Please specify a AdminPassword variable."}
 export TRANSPORTURL=${TransportURL:-""}
 export BACKENDURL=${BackendURL:-"redis://redis:6379/"}
-export BACKENDTYPE=${BackendType:-"None"}
 
 VERBOSE="True"
 
@@ -96,38 +95,6 @@ if [ -n "$TRANSPORTURL" ]; then
 fi
 if [ -n "$BACKENDURL" ]; then
     crudini --set ${SVC_CFG_MERGED} coordination backend_url $BACKENDURL
-fi
-
-# Determine what the backend we are using and initialize accordingly.
-if [ "$BACKENDTYPE" == "bind9" ]; then
-    msgout "INFO" "bind9 setup"
-    # setup some critical env vars
-    BIND_SERVICE_NAME=named
-    BIND_CFG_DIR=/etc/named
-    BIND_CFG_FILE=/etc/named/named.conf
-    BIND_VAR_DIR=/var/named
-    BIND_CACHE_DIR=/var/cache/named
-    BIND_USER=named
-    BIND_GROUP=named
-    BIND_PORT=53
-    RNDC_PORT=953
-    MYIPADDR=$(hostname --ip-address)
-
-    setup_bind9
-
-    # change the tags to values
-    sudo sed -i 's/IPV4ADDR/'$MYIPADDR'/g' $BIND_CFG_FILE
-    sudo sed -i 's/BINDPORT/'$BIND_PORT'/g' $BIND_CFG_FILE
-    sudo sed -i 's/RNDCPORT/'$RNDC_PORT'/g' $BIND_CFG_FILE
-
-    sed -i 's/IPV4ADDR/'$MYIPADDR'/g' $BIND_CFG_DIR/rndc.conf
-    sed -i 's/RNDCPORT/'$RNDC_PORT'/g' $BIND_CFG_DIR/rndc.conf
-
-
-elif [ "$BACKENDTYPE" = "unbound" ]; then
-    msgout "INFO" "unbound setup ****UNDER CONSTRUCTION***"
-elif [ "$BACKENDTYPE" = "byo" ]; then
-    msgout "INFO" "BYO server setup ****UNDER CONSTRUCTION***"
 fi
 
 # NOTE:dkehn - REMOVED because Kolla_set & start copy eveyrthing.

--- a/templates/designate/config/init_setup.sh
+++ b/templates/designate/config/init_setup.sh
@@ -6,4 +6,3 @@ export DatabasePassword=12345678
 export DatabaseName=designate
 export TransportURL=rabbit://default_user_P3R2c2-n3Pzpj1Gx6lf:9Z3RBQHdSeb4VU1fwoRbpt-UNa7jgLE0@rabbitmq.openstack.svc:5672
 export BackendURL=redis://redis:6379/
-export BackendType=bind9


### PR DESCRIPTION
We do not support, nor do we have any plan to support DNS servers other than bind9 for the forseeable future. While we cannot remove it from the API, this patch removes it from the places it is used to avoid confusion or errorneous values from causing unexpected behaviour.