### PR TITLE
Generate an rndc key per bind instance

### DIFF
--- a/pkg/designate/const.go
+++ b/pkg/designate/const.go
@@ -34,4 +34,8 @@ const (
 	DesignatePublicPort int32 = 9001
 	// DesignateInternalPort -
 	DesignateInternalPort int32 = 9001
+
+	DesignateBindKeySecret = "designate-bind-secret"
+
+	DesignateRndcKey = "rndc-key"
 )

--- a/pkg/designate/rndckeygenerator.go
+++ b/pkg/designate/rndckeygenerator.go
@@ -20,6 +20,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"fmt"
 	"log"
 	"math/big"
 )
@@ -65,5 +66,12 @@ func CreateRndcKeySecret() (string, error) {
 
 	// Encode to base64
 	secret := base64.StdEncoding.EncodeToString(digest)
-	return secret, nil
+
+	// Format the key content according to the required structure
+	rndcKeyContent := fmt.Sprintf(`key "rndc-key" {
+		algorithm hmac-sha256;
+		secret "%s";
+	};`, secret)
+
+	return rndcKeyContent, nil
 }


### PR DESCRIPTION
This PR adds the option of rndc key files generation. Given the bind replicas value, it allows Designate operator to either create or delete rndc/bind secrets.