### PR TITLE
Implement predictable IP generation for miniDNS

### DIFF
--- a/api/bases/designate.openstack.org_designates.yaml
+++ b/api/bases/designate.openstack.org_designates.yaml
@@ -940,6 +940,11 @@ spec:
                 required:
                 - containerImage
                 type: object
+              designateNetworkAttachment:
+                default: designate
+                description: DesignateNetworkAttachment is a NetworkAttachment resource
+                  name for the Designate Control Network
+                type: string
               designateProducer:
                 description: DesignateProducer - Spec definition for the Producer
                   service of this Designate deployment
@@ -1473,6 +1478,7 @@ spec:
             - designateBackendbind9
             - designateCentral
             - designateMdns
+            - designateNetworkAttachment
             - designateProducer
             - designateWorker
             - rabbitMqClusterName

--- a/api/v1beta1/designate_types.go
+++ b/api/v1beta1/designate_types.go
@@ -176,6 +176,11 @@ type DesignateSpecBase struct {
 	// Resources - Compute Resources required by this service (Limits/Requests).
 	// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+
+	// +kubebuilder:validation:Required
+	// +kubebuilder:default=designate
+	// DesignateNetworkAttachment is a NetworkAttachment resource name for the Designate Control Network
+	DesignateNetworkAttachment string `json:"designateNetworkAttachment"`
 }
 
 // DesignateStatus defines the observed state of Designate

--- a/config/crd/bases/designate.openstack.org_designates.yaml
+++ b/config/crd/bases/designate.openstack.org_designates.yaml
@@ -940,6 +940,11 @@ spec:
                 required:
                 - containerImage
                 type: object
+              designateNetworkAttachment:
+                default: designate
+                description: DesignateNetworkAttachment is a NetworkAttachment resource
+                  name for the Designate Control Network
+                type: string
               designateProducer:
                 description: DesignateProducer - Spec definition for the Producer
                   service of this Designate deployment
@@ -1473,6 +1478,7 @@ spec:
             - designateBackendbind9
             - designateCentral
             - designateMdns
+            - designateNetworkAttachment
             - designateProducer
             - designateWorker
             - rabbitMqClusterName

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,6 +8,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - create

--- a/controllers/designatemdns_controller.go
+++ b/controllers/designatemdns_controller.go
@@ -43,6 +43,7 @@ import (
 	designatemdns "github.com/openstack-k8s-operators/designate-operator/pkg/designatemdns"
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/daemonset"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -489,7 +490,7 @@ func (r *DesignateMdnsReconciler) reconcileNormal(ctx context.Context, instance 
 	// create hash over all the different input resources to identify if any those changed
 	// and a restart/recreate is required.
 	//
-	inputHash, hashChanged, err := r.createHashOfInputHashes(ctx, instance, configMapVars)
+	inputHash, hashChanged, err := r.createHashOfInputHashes(ctx, helper, instance, configMapVars)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.ServiceConfigReadyCondition,
@@ -803,6 +804,7 @@ func (r *DesignateMdnsReconciler) generateServiceConfigMaps(
 // returns the hash, whether the hash changed (as a bool) and any error
 func (r *DesignateMdnsReconciler) createHashOfInputHashes(
 	ctx context.Context,
+	h *helper.Helper,
 	instance *designatev1beta1.DesignateMdns,
 	envVars map[string]env.Setter,
 ) (string, bool, error) {
@@ -810,6 +812,22 @@ func (r *DesignateMdnsReconciler) createHashOfInputHashes(
 
 	var hashMap map[string]string
 	changed := false
+
+	// If MdnsPredIPConfigMap exists, add its hash to status hash
+	mdnsPredIPCM := &corev1.ConfigMap{}
+	err := h.GetClient().Get(ctx, types.NamespacedName{
+		Name:      designate.MdnsPredIPConfigMap,
+		Namespace: instance.Namespace,
+	}, mdnsPredIPCM)
+	if err != nil {
+		Log.Error(err, "Unable to retrieve Mdns predictable IPs ConfigMap")
+		return "", false, err
+	}
+	mdnsPredIPCMHash, err := configmap.Hash(mdnsPredIPCM)
+	if err != nil {
+		return mdnsPredIPCMHash, changed, err
+	}
+
 	mergedMapVars := env.MergeEnvs([]corev1.EnvVar{}, envVars)
 	hash, err := util.ObjectHash(mergedMapVars)
 	if err != nil {

--- a/pkg/designate/bind_ctrl_network.go
+++ b/pkg/designate/bind_ctrl_network.go
@@ -1,0 +1,56 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+@you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package designate
+
+import (
+	"fmt"
+)
+
+// GetPredictableIPAM returns a struct describing the available IP range. If the
+// IP pool size does not fit in given networkParameters CIDR it will return an
+// error instead.
+func GetPredictableIPAM(networkParameters *NetworkParameters) (*NADIpam, error) {
+	predParams := &NADIpam{}
+	predParams.CIDR = networkParameters.CIDR
+	predParams.RangeStart = networkParameters.ProviderAllocationEnd.Next()
+	endRange := predParams.RangeStart
+	for i := 0; i < BindProvPredictablePoolSize; i++ {
+		if !predParams.CIDR.Contains(endRange) {
+			return nil, fmt.Errorf("predictable IPs: cannot allocate %d IP addresses in %s", BindProvPredictablePoolSize, predParams.CIDR)
+		}
+		endRange = endRange.Next()
+	}
+	predParams.RangeEnd = endRange
+	return predParams, nil
+}
+
+// GetNextIP picks the next available IP from the range defined by a NADIpam,
+// skipping ones that are already used appear as keys in the currentValues map.
+func GetNextIP(predParams *NADIpam, currentValues map[string]bool) (string, error) {
+	candidateAddress := predParams.RangeStart
+	for alloced := true; alloced; {
+
+		if _, ok := currentValues[candidateAddress.String()]; ok {
+			if candidateAddress == predParams.RangeEnd {
+				return "", fmt.Errorf("predictable IPs: out of available addresses")
+			}
+			candidateAddress = candidateAddress.Next()
+		} else {
+			alloced = false
+		}
+	}
+	currentValues[candidateAddress.String()] = true
+	return candidateAddress.String(), nil
+}

--- a/pkg/designate/const.go
+++ b/pkg/designate/const.go
@@ -38,4 +38,6 @@ const (
 	DesignateBindKeySecret = "designate-bind-secret"
 
 	DesignateRndcKey = "rndc-key"
+
+	MdnsPredIPConfigMap = "designate-mdns-ip-map"
 )

--- a/pkg/designate/network_consts.go
+++ b/pkg/designate/network_consts.go
@@ -1,0 +1,26 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package designate
+
+// NOTE: Strictly speaking, these don't have to be package scope constants, but having them externally
+// accessible might aide constructing functional tests later on.
+
+const (
+	// Common consts for Control network
+
+	// BindProvPredictablePoolSize  -
+	BindProvPredictablePoolSize = 25
+)

--- a/pkg/designate/network_parameters.go
+++ b/pkg/designate/network_parameters.go
@@ -1,0 +1,87 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+@you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package designate
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/netip"
+
+	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+)
+
+// NetworkParameters - Parameters for the Designate networks, based on the config of the NAD
+type NetworkParameters struct {
+	CIDR                    netip.Prefix
+	ProviderAllocationStart netip.Addr
+	ProviderAllocationEnd   netip.Addr
+}
+
+// NADConfig - IPAM parameters of the NAD
+type NADConfig struct {
+	IPAM NADIpam `json:"ipam"`
+}
+
+type NADIpam struct {
+	CIDR       netip.Prefix `json:"range"`
+	RangeStart netip.Addr   `json:"range_start"`
+	RangeEnd   netip.Addr   `json:"range_end"`
+}
+
+func getConfigFromNAD(
+	nad *networkv1.NetworkAttachmentDefinition,
+) (*NADConfig, error) {
+	nadConfig := &NADConfig{}
+	jsonDoc := []byte(nad.Spec.Config)
+	err := json.Unmarshal(jsonDoc, nadConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return nadConfig, nil
+}
+
+// GetNetworkParametersFromNAD - Extract network information from the Network Attachment Definition
+func GetNetworkParametersFromNAD(
+	nad *networkv1.NetworkAttachmentDefinition,
+) (*NetworkParameters, error) {
+	networkParameters := &NetworkParameters{}
+
+	nadConfig, err := getConfigFromNAD(nad)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read network parameters: %w", err)
+	}
+
+	// Designate CIDR parameters
+	// These are the parameters for Designate's net/subnet
+	networkParameters.CIDR = nadConfig.IPAM.CIDR
+
+	// OpenShift allocates IP addresses from IPAM.RangeStart to IPAM.RangeEnd
+	// for the pods.
+	// We're going to use a range of 25 IP addresses that are assigned to
+	// the Neutron allocation pool, the range starts right after OpenShift
+	// RangeEnd.
+	networkParameters.ProviderAllocationStart = nadConfig.IPAM.RangeEnd.Next()
+	end := networkParameters.ProviderAllocationStart
+	for i := 0; i < BindProvPredictablePoolSize; i++ {
+		if !networkParameters.CIDR.Contains(end) {
+			return nil, fmt.Errorf("cannot allocate %d IP addresses in %s", BindProvPredictablePoolSize, networkParameters.CIDR)
+		}
+		end = end.Next()
+	}
+	networkParameters.ProviderAllocationEnd = end
+
+	return networkParameters, err
+}

--- a/pkg/designatemdns/daemonset.go
+++ b/pkg/designatemdns/daemonset.go
@@ -43,11 +43,9 @@ func DaemonSet(
 	annotations map[string]string,
 ) *appsv1.DaemonSet {
 	rootUser := int64(0)
-
-	volumes := designate.GetVolumes(
-		designate.GetOwningDesignateName(instance),
-	)
-	volumeMounts := designate.GetVolumeMounts("designate-mdns")
+	serviceName := fmt.Sprintf("%s-mdns", designate.ServiceName)
+	volumes := GetVolumes(designate.GetOwningDesignateName(instance))
+	volumeMounts := GetVolumeMounts(serviceName)
 
 	livenessProbe := &corev1.Probe{
 		// TODO might need tuning
@@ -73,8 +71,6 @@ func DaemonSet(
 	envVars := map[string]env.Setter{}
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
-
-	serviceName := fmt.Sprintf("%s-mdns", designate.ServiceName)
 
 	// Add the CA bundle
 	if instance.Spec.TLS.CaBundleSecretName != "" {

--- a/pkg/designatemdns/volumes.go
+++ b/pkg/designatemdns/volumes.go
@@ -1,0 +1,49 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package designatemdns
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openstack-k8s-operators/designate-operator/pkg/designate"
+)
+
+func GetVolumes(name string) []corev1.Volume {
+	var config0640AccessMode int32 = 0640
+	return append(
+		designate.GetVolumes(name),
+		corev1.Volume{
+			Name: "bind-ips",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: designate.MdnsPredIPConfigMap,
+					},
+					DefaultMode: &config0640AccessMode,
+				},
+			},
+		},
+	)
+}
+
+func GetVolumeMounts(serviceName string) []corev1.VolumeMount {
+	return append(
+		designate.GetVolumeMounts(serviceName),
+		corev1.VolumeMount{
+			Name:      "bind-ips",
+			MountPath: "/var/lib/bind-ips",
+			ReadOnly:  true,
+		},
+	)
+}


### PR DESCRIPTION
The designate miniDNS needs a predictable IP mechanism, as it is a
daemonset and will use the list of available workers to generate a list
of IPs that are valid for the designate network attachment's CIDR range
but do not overlap with the address range defined in the attachment's
IPAM config.

This patch adds it.