### PR TITLE
Add a pools.yaml generator example

### DIFF
--- a/controllers/designateworker_controller.go
+++ b/controllers/designateworker_controller.go
@@ -827,6 +827,7 @@ func (r *DesignateWorkerReconciler) createHashOfInputHashes(
 	if err != nil {
 		return hash, changed, err
 	}
+
 	if hashMap, changed = util.SetHash(instance.Status.Hash, common.InputHashName, hash); changed {
 		instance.Status.Hash = hashMap
 		Log.Info(fmt.Sprintf("Input maps hash %s - %s", common.InputHashName, hash))

--- a/demo/examples/generate_bind9_multipool_pools_yaml/generate_bind9_multipool_pools_yaml.go
+++ b/demo/examples/generate_bind9_multipool_pools_yaml/generate_bind9_multipool_pools_yaml.go
@@ -1,0 +1,206 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"os"
+	"text/template"
+)
+
+type Pool struct {
+	Name        string
+	Description string
+	Attributes  map[string]string
+	NSRecords   []NSRecord
+	Nameservers []Nameserver
+	Targets     []Target
+	CatalogZone *CatalogZone // it is a pointer because it is optional
+}
+
+type NSRecord struct {
+	Hostname string
+	Priority int
+}
+
+type Nameserver struct {
+	Host string
+	Port int
+}
+
+type Target struct {
+	Type        string
+	Description string
+	Masters     []Master
+	Options     Options
+}
+
+type Master struct {
+	Host string
+	Port int
+}
+
+type Options struct {
+	Host           string
+	Port           int
+	RNDCHost       string
+	RNDCPort       int
+	RNDCConfigFile string
+}
+
+type CatalogZone struct {
+	FQDN    string
+	Refresh string
+}
+
+func main() {
+	attributes := map[string]string{
+		"type": "internal",
+	}
+
+	// Catalog zone is an optional section
+	catalogZone := &CatalogZone{
+		FQDN:    "example.org.",
+		Refresh: "60",
+	}
+
+	pool1 := Pool{
+		Name:        "default",
+		Description: "DevStack BIND Pool",
+		Attributes:  attributes,
+		NSRecords: []NSRecord{
+			{Hostname: "ns1.devstack.org.", Priority: 1},
+		},
+		Nameservers: []Nameserver{
+			{Host: "192.168.124.114", Port: 53},
+		},
+		Targets: []Target{
+			{
+				Type:        "bind9",
+				Description: "BIND Instance",
+				Masters: []Master{
+					{Host: "192.168.124.114", Port: 5354},
+				},
+				Options: Options{
+					Host:           "192.168.124.114",
+					Port:           53,
+					RNDCHost:       "192.168.124.114",
+					RNDCPort:       953,
+					RNDCConfigFile: "/etc/named/rndc.conf",
+				},
+			},
+		},
+		CatalogZone: catalogZone,
+	}
+	// Second pool definition
+	attributes = map[string]string{
+		"type": "external",
+	}
+	pool2 := Pool{
+		Name:        "secondary_pool",
+		Description: "DevStack BIND Pool 2",
+		Attributes:  attributes,
+		NSRecords: []NSRecord{
+			{Hostname: "ns1.devstack.org.", Priority: 1},
+		},
+		Nameservers: []Nameserver{
+			{Host: "192.168.124.114", Port: 1053},
+		},
+		Targets: []Target{
+			{
+				Type:        "bind9",
+				Description: "BIND Instance 2nd pool",
+				Masters: []Master{
+					{Host: "192.168.124.114", Port: 5354},
+				},
+				Options: Options{
+					Host:           "192.168.124.114",
+					Port:           1053,
+					RNDCHost:       "192.168.124.114",
+					RNDCPort:       1953,
+					RNDCConfigFile: "/etc/named-2/rndc.conf",
+				},
+			},
+		},
+		CatalogZone: nil, // No catalog zone for the second pool
+	}
+
+	pools := []Pool{pool1, pool2}
+
+	tmpl, err := template.New("pools").Parse(multipoolTemplate)
+	if err != nil {
+		panic(err)
+	}
+
+	f, err := os.Create("pools.yaml")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	err = tmpl.Execute(f, pools)
+	if err != nil {
+		panic(err)
+	}
+}
+
+const multipoolTemplate = `
+---
+{{- range . }}
+- name: {{.Name}}
+  description: {{.Description}}
+  attributes: {
+    {{- range $key, $value := .Attributes }}
+    "{{ $key }}": "{{ $value }}",
+    {{- end }}
+  }
+
+  ns_records:
+    {{- range .NSRecords }}
+    - hostname: {{.Hostname}}
+      priority: {{.Priority}}
+    {{- end }}
+
+  nameservers:
+    {{- range .Nameservers }}
+    - host: {{.Host}}
+      port: {{.Port}}
+    {{- end }}
+
+  targets:
+    {{- range .Targets }}
+    - type: {{.Type}}
+      description: {{.Description}}
+
+      masters:
+        {{- range .Masters }}
+        - host: {{.Host}}
+          port: {{.Port}}
+        {{- end }}
+
+      options:
+        host: {{.Options.Host}}
+        port: {{.Options.Port}}
+        rndc_host: {{.Options.RNDCHost}}
+        rndc_port: {{.Options.RNDCPort}}
+        rndc_config_file: {{.Options.RNDCConfigFile}}
+    {{- end }}
+
+  {{- if .CatalogZone }}
+
+  catalog_zone:
+    catalog_zone_fqdn: {{.CatalogZone.FQDN}}
+    catalog_zone_refresh: '{{.CatalogZone.Refresh}}'
+	{{- end }}
+{{- end }}
+`

--- a/demo/examples/generate_bind9_pools_yaml/generate_bind9_pools_yaml.go
+++ b/demo/examples/generate_bind9_pools_yaml/generate_bind9_pools_yaml.go
@@ -1,0 +1,170 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"os"
+	"text/template"
+)
+
+type Pool struct {
+	Name        string
+	Description string
+	Attributes  map[string]string
+	NSRecords   []NSRecord
+	Nameservers []Nameserver
+	Targets     []Target
+	CatalogZone *CatalogZone // it is a pointer because it is optional
+}
+
+type NSRecord struct {
+	Hostname string
+	Priority int
+}
+
+type Nameserver struct {
+	Host string
+	Port int
+}
+
+type Target struct {
+	Type        string
+	Description string
+	Masters     []Master
+	Options     Options
+}
+
+type Master struct {
+	Host string
+	Port int
+}
+
+type Options struct {
+	Host           string
+	Port           int
+	RNDCHost       string
+	RNDCPort       int
+	RNDCConfigFile string
+}
+
+type CatalogZone struct {
+	FQDN    string
+	Refresh string
+}
+
+func main() {
+	attributes := map[string]string{
+		"pool_level": "default",
+		"type":       "internal",
+	}
+
+	// Catalog zone is an optional section
+	// catalogZone := &CatalogZone{
+	// 	FQDN:    "example.org.",
+	// 	Refresh: "60",
+	// }
+
+	pool := Pool{
+		Name:        "default",
+		Description: "DevStack BIND Pool",
+		Attributes:  attributes,
+		NSRecords: []NSRecord{
+			{Hostname: "ns1.devstack.org.", Priority: 1},
+		},
+		Nameservers: []Nameserver{
+			{Host: "192.168.124.114", Port: 53},
+		},
+		Targets: []Target{
+			{
+				Type:        "bind9",
+				Description: "BIND Instance",
+				Masters: []Master{
+					{Host: "192.168.124.114", Port: 5354},
+				},
+				Options: Options{
+					Host:           "192.168.124.114",
+					Port:           53,
+					RNDCHost:       "192.168.124.114",
+					RNDCPort:       953,
+					RNDCConfigFile: "/etc/named/rndc.conf",
+				},
+			},
+		},
+		CatalogZone: nil, // Set to catalogZone if this section should be presented
+	}
+
+	tmpl, err := template.New("pools").Parse(poolsTemplate)
+	if err != nil {
+		panic(err)
+	}
+
+	f, err := os.Create("pools.yaml")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	err = tmpl.Execute(f, pool)
+	if err != nil {
+		panic(err)
+	}
+}
+
+const poolsTemplate = `
+---
+- name: {{.Name}}
+  description: {{.Description}}
+  attributes: {
+    {{- range $key, $value := .Attributes }}
+    "{{ $key }}": "{{ $value }}",
+    {{- end }}
+  }
+
+  ns_records:
+    {{- range .NSRecords }}
+    - hostname: {{.Hostname}}
+      priority: {{.Priority}}
+    {{- end }}
+
+  nameservers:
+    {{- range .Nameservers }}
+    - host: {{.Host}}
+      port: {{.Port}}
+    {{- end }}
+
+  targets:
+    {{- range .Targets }}
+    - type: {{.Type}}
+      description: {{.Description}}
+
+      masters:
+        {{- range .Masters }}
+        - host: {{.Host}}
+          port: {{.Port}}
+        {{- end }}
+
+      options:
+        host: {{.Options.Host}}
+        port: {{.Options.Port}}
+        rndc_host: {{.Options.RNDCHost}}
+        rndc_port: {{.Options.RNDCPort}}
+        rndc_config_file: {{.Options.RNDCConfigFile}}
+    {{- end }}
+
+  {{- if .CatalogZone }}
+  catalog_zone:
+    catalog_zone_fqdn: {{.CatalogZone.FQDN}}
+    catalog_zone_refresh: '{{.CatalogZone.Refresh}}'
+  {{- end }}
+`

--- a/pkg/designate/bind_ctrl_network.go
+++ b/pkg/designate/bind_ctrl_network.go
@@ -36,21 +36,12 @@ func GetPredictableIPAM(networkParameters *NetworkParameters) (*NADIpam, error) 
 	return predParams, nil
 }
 
-// GetNextIP picks the next available IP from the range defined by a NADIpam,
-// skipping ones that are already used appear as keys in the currentValues map.
-func GetNextIP(predParams *NADIpam, currentValues map[string]bool) (string, error) {
-	candidateAddress := predParams.RangeStart
-	for alloced := true; alloced; {
-
-		if _, ok := currentValues[candidateAddress.String()]; ok {
-			if candidateAddress == predParams.RangeEnd {
-				return "", fmt.Errorf("predictable IPs: out of available addresses")
-			}
-			candidateAddress = candidateAddress.Next()
-		} else {
-			alloced = false
+func GetNextIP(predParams *NADIpam, allocatedIPs map[string]bool) (string, error) {
+	for candidateAddress := predParams.RangeStart; candidateAddress != predParams.RangeEnd; candidateAddress = candidateAddress.Next() {
+		if !allocatedIPs[candidateAddress.String()] {
+			allocatedIPs[candidateAddress.String()] = true
+			return candidateAddress.String(), nil
 		}
 	}
-	currentValues[candidateAddress.String()] = true
-	return candidateAddress.String(), nil
+	return "", fmt.Errorf("predictable IPs: out of available addresses")
 }

--- a/pkg/designate/const.go
+++ b/pkg/designate/const.go
@@ -40,4 +40,6 @@ const (
 	DesignateRndcKey = "rndc-key"
 
 	MdnsPredIPConfigMap = "designate-mdns-ip-map"
+
+	BindPredIPConfigMap = "designate-bind-ip-map"
 )

--- a/pkg/designate/const.go
+++ b/pkg/designate/const.go
@@ -42,4 +42,8 @@ const (
 	MdnsPredIPConfigMap = "designate-mdns-ip-map"
 
 	BindPredIPConfigMap = "designate-bind-ip-map"
+
+	RndcConfDir = "/etc/designate/rndc-keys"
+
+	PoolsYamlsConfigMap = "designate-pools-yaml-config-map"
 )

--- a/pkg/designate/generate_bind9_pools_yaml.go
+++ b/pkg/designate/generate_bind9_pools_yaml.go
@@ -1,0 +1,216 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package designate
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+)
+
+// PoolData represents the data GeneratePoolsYamlFile will receive from the controller
+type PoolData struct {
+	MdnsMap    map[string]string
+	BindMap    map[string]string
+	Attributes map[string]string
+}
+
+type Pool struct {
+	Name        string
+	Description string
+	Attributes  map[string]string
+	NSRecords   []NSRecord
+	Nameservers []Nameserver
+	Targets     []Target
+	CatalogZone *CatalogZone // it is a pointer because it is optional
+}
+
+type NSRecord struct {
+	Hostname string
+	Priority int
+}
+
+type Nameserver struct {
+	Host string
+	Port int
+}
+
+type Target struct {
+	Type        string
+	Description string
+	Masters     []Master
+	Options     Options
+}
+
+type Master struct {
+	Host string
+	Port int
+}
+
+type Options struct {
+	Host           string
+	Port           int
+	RNDCHost       string
+	RNDCPort       int
+	RNDCConfigFile string
+}
+
+type CatalogZone struct {
+	FQDN    string
+	Refresh string
+}
+
+func GeneratePoolsYamlFile(pooslData []PoolData) (string, error) {
+	var buf bytes.Buffer
+	buf.WriteString("\n---\n")
+
+	for _, poolData := range pooslData {
+		// Create ns_records
+		nsRecords := []NSRecord{}
+		priority := 1
+
+		for i := 0; i < 3; i++ { // TODO oschwart: implement ns_records part - I chose 3 randomly
+			nsRecord := NSRecord{
+				Hostname: fmt.Sprintf("ns%d.example.org.", priority),
+				Priority: priority,
+			}
+			nsRecords = append(nsRecords, nsRecord)
+			priority++
+		}
+
+		// As far as I understand, we will only have one mdnsIP (primary DNS server)
+		var mdnsIP string
+		for _, v := range poolData.MdnsMap {
+			mdnsIP = v
+			break
+		}
+
+		// Create targets and nameservers
+		nameservers := []Nameserver{}
+		targets := []Target{}
+		rndcKeyNum := 1
+
+		for _, bindIP := range poolData.BindMap {
+			nameservers = append(nameservers, Nameserver{
+				Host: bindIP,
+				Port: 53,
+			})
+
+			target := Target{
+				Type:        "bind9",
+				Description: fmt.Sprintf("BIND9 Server %d (%s)", rndcKeyNum, bindIP),
+				Masters: []Master{
+					{
+						Host: mdnsIP,
+						Port: 16000, // TODO oschwart: change it to the real value
+					},
+					{
+						Host: mdnsIP,
+						Port: 16001, // TODO oschwart: change it to the real value
+					},
+					{
+						Host: mdnsIP,
+						Port: 16002, // TODO oschwart: change it to the real value
+					},
+				},
+				Options: Options{
+					Host:           bindIP,
+					Port:           53,
+					RNDCHost:       bindIP,
+					RNDCPort:       953,
+					RNDCConfigFile: fmt.Sprintf("%s/%s-%d.conf", RndcConfDir, DesignateRndcKey, rndcKeyNum),
+				},
+			}
+			targets = append(targets, target)
+			rndcKeyNum++
+		}
+
+		// Catalog zone is an optional section
+		// catalogZone := &CatalogZone{
+		// 	FQDN:    "example.org.",
+		// 	Refresh: "60",
+		// }
+
+		// Create the Pool struct with the dynamic values
+		pool := Pool{
+			Name:        "default",
+			Description: "DevStack BIND Pool",
+			Attributes:  poolData.Attributes,
+			NSRecords:   nsRecords,
+			Nameservers: nameservers,
+			Targets:     targets,
+			CatalogZone: nil, // set to catalogZone if this section should be presented
+		}
+
+		// Parse the template and return it as a string
+		tmpl, err := template.New("pool").Parse(poolsTemplate)
+		if err != nil {
+			return "", err
+		}
+
+		err = tmpl.Execute(&buf, pool)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return buf.String(), nil
+}
+
+const poolsTemplate = `
+- name: {{.Name}}
+  description: {{.Description}}
+  attributes: {
+    {{- range $key, $value := .Attributes }}
+    "{{ $key }}": "{{ $value }}",
+    {{- end }}
+  }
+
+  ns_records:
+    {{- range .NSRecords }}
+    - hostname: {{.Hostname}}
+      priority: {{.Priority}}
+    {{- end }}
+
+  nameservers:
+    {{- range .Nameservers }}
+    - host: {{.Host}}
+      port: {{.Port}}
+    {{- end }}
+
+  targets:
+    {{- range .Targets }}
+    - type: {{.Type}}
+      description: {{.Description}}
+
+      masters:
+        {{- range .Masters }}
+        - host: {{.Host}}
+          port: {{.Port}}
+        {{- end }}
+
+      options:
+        host: {{.Options.Host}}
+        port: {{.Options.Port}}
+        rndc_host: {{.Options.RNDCHost}}
+        rndc_port: {{.Options.RNDCPort}}
+        rndc_config_file: {{.Options.RNDCConfigFile}}
+    {{- end }}
+
+  {{- if .CatalogZone }}
+  catalog_zone:
+    catalog_zone_fqdn: {{.CatalogZone.FQDN}}
+    catalog_zone_refresh: '{{.CatalogZone.Refresh}}'
+  {{- end }}
+`


### PR DESCRIPTION
This patch adds an example to a pools.yaml file generator, it uses dummy data that was taken from a devstack deployment, and does not support multipool (yet).