### PR TITLE
Make sure to log error in findObjectsForSrc()

### DIFF
--- a/controllers/designateapi_controller.go
+++ b/controllers/designateapi_controller.go
@@ -367,7 +367,8 @@ func (r *DesignateAPIReconciler) findObjectsForSrc(ctx context.Context, src clie
 		}
 		err := r.Client.List(context.TODO(), crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/designatecentral_controller.go
+++ b/controllers/designatecentral_controller.go
@@ -322,7 +322,8 @@ func (r *DesignateCentralReconciler) findObjectsForSrc(ctx context.Context, src 
 		}
 		err := r.Client.List(context.TODO(), crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/designatemdns_controller.go
+++ b/controllers/designatemdns_controller.go
@@ -321,7 +321,8 @@ func (r *DesignateMdnsReconciler) findObjectsForSrc(ctx context.Context, src cli
 		}
 		err := r.Client.List(context.TODO(), crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/designateproducer_controller.go
+++ b/controllers/designateproducer_controller.go
@@ -321,7 +321,8 @@ func (r *DesignateProducerReconciler) findObjectsForSrc(ctx context.Context, src
 		}
 		err := r.Client.List(context.TODO(), crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {

--- a/controllers/designateworker_controller.go
+++ b/controllers/designateworker_controller.go
@@ -321,7 +321,8 @@ func (r *DesignateWorkerReconciler) findObjectsForSrc(ctx context.Context, src c
 		}
 		err := r.Client.List(context.TODO(), crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {


### PR DESCRIPTION
It is hidden right now if there is an error in configured named fields and index. Lets log the error and return the current state of requests.

With this the findObjectsForSrc() will exit with an hidden error like:

```
"error": "Index with name field:.spec.ksmTls.caBundleSecretName does not exist"
```