### PR TITLE
Add a test NAD to allow more code paths to run during testing

### DIFF
--- a/config/samples/designate_v1beta1_designate.yaml
+++ b/config/samples/designate_v1beta1_designate.yaml
@@ -22,12 +22,13 @@ spec:
   designateBackendbind9:
     secret: osp-secret
     serviceUser: designate
+    replicas: 1
     customServiceConfig: |
       [DEFAULT]
       debug = true
     databaseAccount: designate
     rabbitMqClusterName: rabbitmq
-    storageRequest: 1G
+    storageRequest: 10G
     storageClass: local-storage
     networkAttachments:
       - designate

--- a/config/samples/designate_v1beta1_designate_tls.yaml
+++ b/config/samples/designate_v1beta1_designate_tls.yaml
@@ -43,12 +43,13 @@ spec:
       caBundleSecretName: combined-ca-bundle
   designateBackendbind9:
     databaseAccount: designate
+    replicas: 1
     serviceUser: designate
     secret: osp-secret
     customServiceConfig: |
       [DEFAULT]
       debug = true
-    storageRequest: 1G
+    storageRequest: 10G
     storageClass: local-storage
     networkAttachments:
       - designate

--- a/tests/kuttl/common/designate_nad.yaml
+++ b/tests/kuttl/common/designate_nad.yaml
@@ -1,0 +1,21 @@
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: designate
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "designate",
+      "type": "bridge",
+      "ipam": {
+        "type": "whereabouts",
+        "range": "172.28.0.0/24",
+        "range_start": "172.28.0.30",
+        "range_end": "172.28.0.70"
+      }
+    }

--- a/tests/kuttl/tests/basic/deploy/kustomization.yaml
+++ b/tests/kuttl/tests/basic/deploy/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- ./designate_nad.yaml
 - ./designate_v1beta1_designate.yaml

--- a/tests/kuttl/tests/designate_tls/01-nad.yaml
+++ b/tests/kuttl/tests/designate_tls/01-nad.yaml
@@ -2,13 +2,11 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
-      cp ../../../../config/samples/designate_v1beta1_designate.yaml deploy
       # Do not modify the designate network attachment if it already
       # exists.
+      set -e
       if ! (oc get -n $NAMESPACE net-attach-def | grep designate);
       then
-         cp ../../common/designate_nad.yaml deploy
-      else
-         echo "" > deploy/designate_nad.yaml
+         cp ../../common/designate_nad.yaml .
+         oc apply -n $NAMESPACE -f designate_nad.yaml
       fi
-      oc kustomize deploy | oc apply -n $NAMESPACE -f -

--- a/tests/kuttl/tests/designate_tls/02-deploy.yaml
+++ b/tests/kuttl/tests/designate_tls/02-deploy.yaml
@@ -28,6 +28,8 @@ spec:
     customServiceConfig: |
       [DEFAULT]
       debug = true
+    networkAttachments:
+      - designate
     tls:
       caBundleSecretName: combined-ca-bundle
   designateCentral:
@@ -39,6 +41,18 @@ spec:
       debug = true
     tls:
       caBundleSecretName: combined-ca-bundle
+  designateBackendbind9:
+    databaseAccount: designate
+    replicas: 1
+    serviceUser: designate
+    secret: osp-secret
+    customServiceConfig: |
+      [DEFAULT]
+      debug = true
+    storageRequest: 10G
+    storageClass: local-storage
+    networkAttachments:
+      - designate
   designateWorker:
     databaseAccount: designate
     serviceUser: designate
@@ -46,6 +60,8 @@ spec:
     customServiceConfig: |
       [DEFAULT]
       debug = true
+    networkAttachments:
+      - designate
     tls:
       caBundleSecretName: combined-ca-bundle
   designateAPI:


### PR DESCRIPTION
Adds a NAD so functionality such as predictable IPs and bind pool generation can be tested via kuttl. This NAD is not appropriate iif kuttl tests use multiple openshift workers as the NAD is a bridge type.