### PR TITLE
Add  predictable IPs to mdns and bind9

### DIFF
--- a/api/bases/designate.openstack.org_designatebackendbind9s.yaml
+++ b/api/bases/designate.openstack.org_designatebackendbind9s.yaml
@@ -109,6 +109,9 @@ spec:
                   But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                   TODO: -> implement
                 type: object
+              netUtilsImage:
+                description: NetUtilsImage - NetUtils container image
+                type: string
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
                   names to expose the services to the given network

--- a/api/bases/designate.openstack.org_designatemdnses.yaml
+++ b/api/bases/designate.openstack.org_designatemdnses.yaml
@@ -109,6 +109,9 @@ spec:
                   But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                   TODO: -> implement
                 type: object
+              netUtilsImage:
+                description: NetUtilsImage - NetUtils container image
+                type: string
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
                   names to expose the services to the given network

--- a/api/bases/designate.openstack.org_designates.yaml
+++ b/api/bases/designate.openstack.org_designates.yaml
@@ -515,6 +515,9 @@ spec:
                       But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                       TODO: -> implement
                     type: object
+                  netUtilsImage:
+                    description: NetUtilsImage - NetUtils container image
+                    type: string
                   networkAttachments:
                     description: NetworkAttachments is a list of NetworkAttachment
                       resource names to expose the services to the given network
@@ -866,6 +869,9 @@ spec:
                       But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                       TODO: -> implement
                     type: object
+                  netUtilsImage:
+                    description: NetUtilsImage - NetUtils container image
+                    type: string
                   networkAttachments:
                     description: NetworkAttachments is a list of NetworkAttachment
                       resource names to expose the services to the given network

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -37,6 +37,8 @@ const (
 	DesignateUnboundContainerImage = "quay.io/podified-antelope-centos9/openstack-unbound:current-podified"
 	// DesignateBackendbind9ContainerImage is the fall-back container image for DesignateUnbound
 	DesignateBackendbind9ContainerImage = "quay.io/podified-antelope-centos9/openstack-designate-backend-bind9:current-podified"
+	// NetUtilsContainerImage is the container image containing support for predictable IP pod injection
+	NetUtilsContainerImage = "quay.io/podified-antelope-centos9/openstack-netutils:current-podified"
 )
 
 // DesignateTemplate defines common input parameters used by all Designate services

--- a/api/v1beta1/designate_types.go
+++ b/api/v1beta1/designate_types.go
@@ -297,6 +297,7 @@ func SetupDefaults() {
 		WorkerContainerImageURL:       util.GetEnvVar("RELATED_IMAGE_DESIGNATE_WORKER_IMAGE_URL_DEFAULT", DesignateWorkerContainerImage),
 		UnboundContainerImageURL:      util.GetEnvVar("RELATED_IMAGE_DESIGNATE_UNBOUND_IMAGE_URL_DEFAULT", DesignateUnboundContainerImage),
 		Backendbind9ContainerImageURL: util.GetEnvVar("RELATED_IMAGE_DESIGNATE_BACKENDBIND9_IMAGE_URL_DEFAULT", DesignateBackendbind9ContainerImage),
+		NetUtilsURL:                   util.GetEnvVar("RELATED_IMAGE_NETUTILS_IMAGE_URL_DEFAULT", NetUtilsContainerImage),
 		DesignateAPIRouteTimeout:      APITimeout,
 	}
 

--- a/api/v1beta1/designate_webhook.go
+++ b/api/v1beta1/designate_webhook.go
@@ -44,6 +44,7 @@ type DesignateDefaults struct {
 	WorkerContainerImageURL       string
 	Backendbind9ContainerImageURL string
 	UnboundContainerImageURL      string
+	NetUtilsURL                   string
 	DesignateAPIRouteTimeout         int
 }
 
@@ -86,6 +87,9 @@ func (spec *DesignateSpec) Default() {
 	if spec.DesignateMdns.ContainerImage == "" {
 		spec.DesignateMdns.ContainerImage = designateDefaults.MdnsContainerImageURL
 	}
+	if spec.DesignateMdns.NetUtilsImage == "" {
+		spec.DesignateMdns.NetUtilsImage = designateDefaults.NetUtilsURL
+	}
 	if spec.DesignateProducer.ContainerImage == "" {
 		spec.DesignateProducer.ContainerImage = designateDefaults.ProducerContainerImageURL
 	}
@@ -94,6 +98,9 @@ func (spec *DesignateSpec) Default() {
 	}
 	if spec.DesignateBackendbind9.ContainerImage == "" {
 		spec.DesignateBackendbind9.ContainerImage = designateDefaults.Backendbind9ContainerImageURL
+	}
+	if spec.DesignateBackendbind9.NetUtilsImage == "" {
+		spec.DesignateBackendbind9.NetUtilsImage = designateDefaults.NetUtilsURL
 	}
 	if spec.DesignateUnbound.ContainerImage == "" {
 		spec.DesignateUnbound.ContainerImage = designateDefaults.UnboundContainerImageURL

--- a/api/v1beta1/designatebackendbind9_types.go
+++ b/api/v1beta1/designatebackendbind9_types.go
@@ -78,6 +78,10 @@ type DesignateBackendbind9SpecBase struct {
 	// +kubebuilder:validation:Optional
 	// StorageRequest
 	StorageRequest string `json:"storageRequest"`
+
+	// +kubebuilder:validation:Optional
+	// NetUtilsImage - NetUtils container image
+	NetUtilsImage string `json:"netUtilsImage"`
 }
 
 // DesignateBackendbind9Status defines the observed state of DesignateBackendbind9

--- a/api/v1beta1/designatemdns_types.go
+++ b/api/v1beta1/designatemdns_types.go
@@ -72,6 +72,10 @@ type DesignateMdnsSpecBase struct {
 	// +kubebuilder:validation:Optional
 	// ControlNetworkName - specify which network attachment is to be used for control, notifys and zone transfers.
 	ControlNetworkName string `json:"controlNetworkName"`
+
+	// +kubebuilder:validation:Optional
+	// NetUtilsImage - NetUtils container image
+	NetUtilsImage string `json:"netUtilsImage"`
 }
 
 // DesignateMdnsStatus defines the observed state of DesignateMdns

--- a/config/crd/bases/designate.openstack.org_designatebackendbind9s.yaml
+++ b/config/crd/bases/designate.openstack.org_designatebackendbind9s.yaml
@@ -109,6 +109,9 @@ spec:
                   But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                   TODO: -> implement
                 type: object
+              netUtilsImage:
+                description: NetUtilsImage - NetUtils container image
+                type: string
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
                   names to expose the services to the given network

--- a/config/crd/bases/designate.openstack.org_designatemdnses.yaml
+++ b/config/crd/bases/designate.openstack.org_designatemdnses.yaml
@@ -109,6 +109,9 @@ spec:
                   But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                   TODO: -> implement
                 type: object
+              netUtilsImage:
+                description: NetUtilsImage - NetUtils container image
+                type: string
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
                   names to expose the services to the given network

--- a/config/crd/bases/designate.openstack.org_designates.yaml
+++ b/config/crd/bases/designate.openstack.org_designates.yaml
@@ -515,6 +515,9 @@ spec:
                       But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                       TODO: -> implement
                     type: object
+                  netUtilsImage:
+                    description: NetUtilsImage - NetUtils container image
+                    type: string
                   networkAttachments:
                     description: NetworkAttachments is a list of NetworkAttachment
                       resource names to expose the services to the given network
@@ -866,6 +869,9 @@ spec:
                       But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                       TODO: -> implement
                     type: object
+                  netUtilsImage:
+                    description: NetUtilsImage - NetUtils container image
+                    type: string
                   networkAttachments:
                     description: NetworkAttachments is a list of NetworkAttachment
                       resource names to expose the services to the given network

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -25,3 +25,5 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-designate-backend-bind9:current-podified
         - name: RELATED_IMAGE_DESIGNATE_UNBOUND_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-unbound:current-podified
+        - name: RELATED_IMAGE_NETUTILS_IMAGE_URL_DEFAULT
+          value: quay.io/podified-antelope-centos9/openstack-netutils:current-podified

--- a/pkg/designate/const.go
+++ b/pkg/designate/const.go
@@ -52,4 +52,13 @@ const (
 	PoolsYamlPath = "templates/designatepoolmanager/config/pools.yaml.tmpl"
 
 	PoolsYamlHash = "pools-yaml-hash"
+
+	// BindPredictableIPHash key for status hash
+	BindPredictableIPHash = "Bind IP Map"
+
+	// RndcHash key for status hash
+	RndcHash = "Rndc keys"
+
+	// PredictableIPCommand -
+	PredictableIPCommand = "/usr/local/bin/container-scripts/setipalias.sh"
 )

--- a/pkg/designate/initcontainer.go
+++ b/pkg/designate/initcontainer.go
@@ -31,10 +31,39 @@ type APIDetails struct {
 	Privileged           bool
 }
 
+type InitContainerDetails struct {
+	ContainerImage string
+	VolumeMounts   []corev1.VolumeMount
+	EnvVars        []corev1.EnvVar
+}
+
 const (
 	// InitContainerCommand -
 	InitContainerCommand = "/usr/local/bin/container-scripts/init.sh"
 )
+
+func SimpleInitContainer(init InitContainerDetails) corev1.Container {
+	runAsUser := int64(0)
+
+	args := []string{
+		"-c",
+		InitContainerCommand,
+	}
+
+	return corev1.Container{
+		Name:  "init",
+		Image: init.ContainerImage,
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser: &runAsUser,
+		},
+		Command: []string{
+			"/bin/bash",
+		},
+		Args:         args,
+		Env:          init.EnvVars,
+		VolumeMounts: init.VolumeMounts,
+	}
+}
 
 // InitContainer - init container for designate api pods
 func InitContainer(init APIDetails) []corev1.Container {

--- a/pkg/designate/predipcontainer.go
+++ b/pkg/designate/predipcontainer.go
@@ -1,0 +1,55 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package designate
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+type PredIPContainerDetails struct {
+	ContainerImage string
+	VolumeMounts   []corev1.VolumeMount
+	Command        string
+	EnvVars        []corev1.EnvVar
+}
+
+func PredictableIPContainer(init PredIPContainerDetails) corev1.Container {
+
+	args := []string{
+		"-c",
+		init.Command,
+	}
+
+	capabilities := []corev1.Capability{"NET_ADMIN", "SYS_ADMIN", "SYS_NICE"}
+	return corev1.Container{
+		Name:  "predictableips",
+		Image: init.ContainerImage,
+		SecurityContext: &corev1.SecurityContext{
+			Capabilities: &corev1.Capabilities{
+				Add:  capabilities,
+				Drop: []corev1.Capability{},
+			},
+			RunAsUser: ptr.To(int64(0)),
+		},
+		Command: []string{
+			"/bin/bash",
+		},
+		Args:         args,
+		Env:          init.EnvVars,
+		VolumeMounts: init.VolumeMounts,
+	}
+}

--- a/pkg/designatebackendbind9/volumes.go
+++ b/pkg/designatebackendbind9/volumes.go
@@ -28,6 +28,7 @@ const (
 	mergedConfigVolume = "designatebackendbind9-config-data-merged"
 	logVolume          = "designatebackendbind9-log-volume"
 	rndcKeys           = "designatebackendbind9-keys"
+	bindIPs            = "designate-bind-ips"
 )
 
 // NOTE(beagles): I vacillated on using designate.GetVolumes() here and appending the extra entries and may still. There
@@ -86,6 +87,17 @@ func getServicePodVolumes(baseConfigMapName string) []corev1.Volume {
 				},
 			},
 		},
+		{
+			Name: bindIPs,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					DefaultMode: &configMode,
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: designate.BindPredIPConfigMap,
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -119,6 +131,20 @@ func getInitVolumeMounts() []corev1.VolumeMount {
 			Name:      rndcKeys,
 			MountPath: "/var/lib/config-data/keys",
 			ReadOnly:  true,
+		},
+	}
+}
+
+func getPredIPVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			Name:      scriptVolume,
+			MountPath: "/usr/local/bin/container-scripts",
+			ReadOnly:  true,
+		},
+		{
+			Name:      bindIPs,
+			MountPath: "/var/lib/predictableips",
 		},
 	}
 }

--- a/pkg/designatemdns/volumes.go
+++ b/pkg/designatemdns/volumes.go
@@ -37,13 +37,16 @@ func GetVolumes(name string) []corev1.Volume {
 	)
 }
 
-func GetVolumeMounts(serviceName string) []corev1.VolumeMount {
-	return append(
-		designate.GetVolumeMounts(serviceName),
-		corev1.VolumeMount{
-			Name:      "bind-ips",
-			MountPath: "/var/lib/bind-ips",
+func getPredIPVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			Name:      "scripts",
+			MountPath: "/usr/local/bin/container-scripts",
 			ReadOnly:  true,
 		},
-	)
+		{
+			Name:      "bind-ips",
+			MountPath: "/var/lib/predictableips",
+		},
+	}
 }

--- a/templates/common/setipalias.py
+++ b/templates/common/setipalias.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python3
+import os
+import sys
+import ipaddress
+import netifaces
+from pyroute2 import IPRoute
+
+mapping_prefix =  os.environ.get("MAP_PREFIX")
+if not len(mapping_prefix):
+    print(f"{sys.argv[0]} requires MAP_PREFIX to be set in environment variables")
+    sys.exit(1)
+
+print(f"Using {mapping_prefix} as the map prefix")
+
+nodefile = ""
+podname = os.environ.get("POD_NAME").strip()
+if not len(podname):
+    print(f"{sys.argv[0]} requires POD_NAME in environment variables")
+    sys.exit(1)
+
+print(f"Pod name is {podname}")
+namepieces = podname.split('-')
+pod_index = namepieces[-1]
+nodefile = f"{mapping_prefix}{pod_index}"
+
+interface_name = os.environ.get("NAD_NAME", "designate").strip()
+
+print(f"working with address file {nodefile}")
+filename = os.path.join('/var/lib/predictableips', nodefile)
+if not os.path.exists(filename):
+    print(f"Required alias address file {filename} does not exist")
+    sys.exit(1)
+
+ip = IPRoute()
+designateinterface = ip.link_lookup(ifname=interface_name)
+
+if not len(designateinterface):
+    print(f"{interface_name} attachment not present")
+    sys.exit(1)
+
+
+ipfile = open(filename, "r")
+ipaddr = ipfile.read()
+ipfile.close()
+
+if ipaddr:
+    print(f"Setting {ipaddr} on {interface_name}")
+    # Get our current addresses so we can avoid trying to set the
+    # same address again.
+    version = ipaddress.ip_address(ipaddr).version
+    ifaceinfo = netifaces.ifaddresses(interface_name)[
+        netifaces.AF_INET if version == 4 else netifaces.AF_INET6]
+    current_addresses = [x['addr'] for x in ifaceinfo]
+    if ipaddr not in current_addresses:
+        mask_value = 32
+        if version == 6:
+            mask_value = 128
+        ip.addr('add', index = designateinterface[0], address=ipaddr, mask=mask_value)
+else:
+    print('No IP address found')
+
+ip.close()

--- a/templates/designate/bin/setipalias.sh
+++ b/templates/designate/bin/setipalias.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2024 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+/usr/local/bin/container-scripts/setipalias.py

--- a/templates/designatebackendbind9/bin/setipalias.sh
+++ b/templates/designatebackendbind9/bin/setipalias.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2024 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+/usr/local/bin/container-scripts/setipalias.py

--- a/templates/designatemdns/bin/init.sh
+++ b/templates/designatemdns/bin/init.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Copyright 2024 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+# expect that the common.sh is in the same dir as the calling script
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+. ${SCRIPTPATH}/common.sh --source-only
+
+# Merge all templates from config CM
+for dir in /var/lib/config-data/default; do
+    merge_config_dir ${dir}
+done

--- a/templates/designatemdns/bin/setipalias.sh
+++ b/templates/designatemdns/bin/setipalias.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright 2024 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+# expect that the common.sh is in the same dir as the calling script
+#
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+/usr/local/bin/container-scripts/setipalias.py

--- a/templates/designatemdns/config/designate-mdns-config.json
+++ b/templates/designatemdns/config/designate-mdns-config.json
@@ -1,17 +1,11 @@
 {
-  "command": "/usr/bin/designate-mdns --config-file /etc/designate/designate.conf --config-dir /etc/designate/designate.conf.d",
+  "command": "/usr/bin/designate-mdns --config-dir /etc/designate/designate.conf",
   "config_files": [
     {
       "source": "/var/lib/config-data/merged/designate.conf",
       "dest": "/etc/designate/designate.conf",
       "owner": "root:designate",
       "perm": "0750"
-    },
-    {
-	"source": "/var/lib/config-data/merged/custom.conf",
-	"dest": "/etc/designate/designate.conf.d/custom.conf",
-	"owner": "designate",
-	"perm": "0600"
     },
     {
       "source": "/var/lib/config-data/merged/my.cnf",

--- a/templates/designatemdns/config/designate.conf
+++ b/templates/designatemdns/config/designate.conf
@@ -1,0 +1,39 @@
+[DEFAULT]
+rpc_response_timeout=60
+quota_api_export_size=1000
+quota_recordset_records=20
+quota_zone_records=500
+quota_zone_recordsets=500
+quota_zones=10
+root-helper=sudo
+state_path=/etc/designate/data
+transport_url={{ .TransportURL }}
+
+[database]
+connection={{ .DatabaseConnection }}
+
+[storage:sqlalchemy]
+connection={{ .DatabaseConnection }}
+
+[service:api]
+quotas_verify_project_id=True
+auth_strategy=keystone
+enable_api_admin=True
+enable_api_v2=True
+enable_host_header=True
+enabled_extensions_admin=quotas
+
+[service:mdns]
+workers=2
+listen=0.0.0.0:5354
+
+[oslo_messaging_notifications]
+topics=notifications
+driver=messagingv2
+
+[oslo_concurrency]
+lock_path=/opt/stack/data/designate
+
+[oslo_policy]
+enforce_scope=True
+enforce_new_defaults=True

--- a/tests/kuttl/common/assert-sample-deployment.yaml
+++ b/tests/kuttl/common/assert-sample-deployment.yaml
@@ -149,7 +149,7 @@ commands:
       imageTuples=$(oc get -n openstack-operators deployment designate-operator-controller-manager -o go-template="$tupleTemplate")
       for ITEM in $(echo $imageTuples); do
         # it is an image
-        if echo $ITEM | grep 'RELATED_IMAGE' &> /dev/null; then
+        if echo $ITEM | grep 'RELATED_IMAGE_DESIGNATE' &> /dev/null; then
           NAME=$(echo $ITEM | sed -e 's|^RELATED_IMAGE_DESIGNATE_\([^_]*\)_.*|\1|')
           IMG_FROM_ENV=$(echo $ITEM | sed -e 's|^.*#\(.*\)|\1|')
           case $NAME in

--- a/tests/kuttl/tests/basic/01-assert.yaml
+++ b/tests/kuttl/tests/basic/01-assert.yaml
@@ -140,7 +140,7 @@ commands:
       imageTuples=$(oc get -n openstack-operators deployment designate-operator-controller-manager -o go-template="$tupleTemplate")
       for ITEM in $(echo $imageTuples); do
         # it is an image
-        if echo $ITEM | grep 'RELATED_IMAGE' &> /dev/null; then
+        if echo $ITEM | grep 'RELATED_IMAGE_DESIGNATE' &> /dev/null; then
           NAME=$(echo $ITEM | sed -e 's|^RELATED_IMAGE_DESIGNATE_\([^_]*\)_.*|\1|')
           IMG_FROM_ENV=$(echo $ITEM | sed -e 's|^.*#\(.*\)|\1|')
           case $NAME in

--- a/tests/kuttl/tests/designate_scale/01-assert.yaml
+++ b/tests/kuttl/tests/designate_scale/01-assert.yaml
@@ -141,7 +141,7 @@ commands:
       imageTuples=$(oc get -n openstack-operators deployment designate-operator-controller-manager -o go-template="$tupleTemplate")
       for ITEM in $(echo $imageTuples); do
         # it is an image
-        if echo $ITEM | grep 'RELATED_IMAGE' &> /dev/null; then
+        if echo $ITEM | grep 'RELATED_IMAGE_DESIGNATE' &> /dev/null; then
           NAME=$(echo $ITEM | sed -e 's|^RELATED_IMAGE_DESIGNATE_\([^_]*\)_.*|\1|')
           IMG_FROM_ENV=$(echo $ITEM | sed -e 's|^.*#\(.*\)|\1|')
           case $NAME in


### PR DESCRIPTION
Adds the predictable IPs to the pod volumes as well as adding some hash tracking logic to the controller.

 Note requires availability of https://github.com/openstack-k8s-operators/tcib/pull/218
