### PR TITLE
Add configurable httpd timeout

### DIFF
--- a/api/bases/designate.openstack.org_designateapis.yaml
+++ b/api/bases/designate.openstack.org_designateapis.yaml
@@ -48,6 +48,10 @@ spec:
           spec:
             description: DesignateAPISpec defines the desired state of DesignateAPI
             properties:
+              apiTimeout:
+                description: APITimeout for HAProxy and Apache defaults to DesignateSpecCore
+                  APITimeout (seconds)
+                type: integer
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
                   be used between the designate-worker & designate_mdns to/from the

--- a/api/bases/designate.openstack.org_designates.yaml
+++ b/api/bases/designate.openstack.org_designates.yaml
@@ -44,6 +44,10 @@ spec:
           spec:
             description: DesignateAPISpec defines the desired state of DesignateAPI
             properties:
+              apiTimeout:
+                default: 120
+                description: Designate API timeout
+                type: integer
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
                   be used between the designate-worker & designate_mdns to/from the
@@ -91,6 +95,10 @@ spec:
                 description: DesignateAPI - Spec definition for the API service of
                   this Designate deployment
                 properties:
+                  apiTimeout:
+                    description: APITimeout for HAProxy and Apache defaults to DesignateSpecCore
+                      APITimeout (seconds)
+                    type: integer
                   backendMdnsServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
                       to be used between the designate-worker & designate_mdns to/from

--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -132,20 +131,4 @@ type PasswordSelector struct {
 	// +kubebuilder:default="DesignatePassword"
 	// Service - Selector to get the designate service password from the Secret
 	Service string `json:"service"`
-}
-
-// SetupDefaults - initializes any CRD field defaults based on environment variables (the defaulting mechanism itself is implemented via webhooks)
-func SetupDefaults() {
-	// Acquire environmental defaults and initialize Designate defaults with them
-	designateDefaults := DesignateDefaults{
-		APIContainerImageURL:          util.GetEnvVar("RELATED_IMAGE_DESIGNATE_API_IMAGE_URL_DEFAULT", DesignateAPIContainerImage),
-		CentralContainerImageURL:      util.GetEnvVar("RELATED_IMAGE_DESIGNATE_CENTRAL_IMAGE_URL_DEFAULT", DesignateCentralContainerImage),
-		MdnsContainerImageURL:         util.GetEnvVar("RELATED_IMAGE_DESIGNATE_MDNS_IMAGE_URL_DEFAULT", DesignateMdnsContainerImage),
-		ProducerContainerImageURL:     util.GetEnvVar("RELATED_IMAGE_DESIGNATE_PRODUCER_IMAGE_URL_DEFAULT", DesignateProducerContainerImage),
-		WorkerContainerImageURL:       util.GetEnvVar("RELATED_IMAGE_DESIGNATE_WORKER_IMAGE_URL_DEFAULT", DesignateWorkerContainerImage),
-		UnboundContainerImageURL:      util.GetEnvVar("RELATED_IMAGE_DESIGNATE_UNBOUND_IMAGE_URL_DEFAULT", DesignateUnboundContainerImage),
-		Backendbind9ContainerImageURL: util.GetEnvVar("RELATED_IMAGE_DESIGNATE_BACKENDBIND9_IMAGE_URL_DEFAULT", DesignateBackendbind9ContainerImage),
-	}
-
-	SetupDesignateDefaults(designateDefaults)
 }

--- a/api/v1beta1/designateapi_types.go
+++ b/api/v1beta1/designateapi_types.go
@@ -78,6 +78,10 @@ type DesignateAPISpecBase struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// TLS - Parameters related to the TLS
 	TLS tls.API `json:"tls,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// APITimeout for HAProxy and Apache defaults to DesignateSpecCore APITimeout (seconds)
+	APITimeout int `json:"apiTimeout"`
 }
 
 // APIOverrideSpec to override the generated manifest of several child resources.

--- a/config/crd/bases/designate.openstack.org_designateapis.yaml
+++ b/config/crd/bases/designate.openstack.org_designateapis.yaml
@@ -48,6 +48,10 @@ spec:
           spec:
             description: DesignateAPISpec defines the desired state of DesignateAPI
             properties:
+              apiTimeout:
+                description: APITimeout for HAProxy and Apache defaults to DesignateSpecCore
+                  APITimeout (seconds)
+                type: integer
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
                   be used between the designate-worker & designate_mdns to/from the

--- a/config/crd/bases/designate.openstack.org_designates.yaml
+++ b/config/crd/bases/designate.openstack.org_designates.yaml
@@ -44,6 +44,10 @@ spec:
           spec:
             description: DesignateAPISpec defines the desired state of DesignateAPI
             properties:
+              apiTimeout:
+                default: 120
+                description: Designate API timeout
+                type: integer
               backendMdnsServerProtocol:
                 description: 'BackendTypeProtocol - Defines the backend protocol to
                   be used between the designate-worker & designate_mdns to/from the
@@ -91,6 +95,10 @@ spec:
                 description: DesignateAPI - Spec definition for the API service of
                   this Designate deployment
                 properties:
+                  apiTimeout:
+                    description: APITimeout for HAProxy and Apache defaults to DesignateSpecCore
+                      APITimeout (seconds)
+                    type: integer
                   backendMdnsServerProtocol:
                     description: 'BackendTypeProtocol - Defines the backend protocol
                       to be used between the designate-worker & designate_mdns to/from

--- a/controllers/designate_controller.go
+++ b/controllers/designate_controller.go
@@ -1488,6 +1488,7 @@ func (r *DesignateReconciler) apiDeploymentCreateOrUpdate(ctx context.Context, i
 		deployment.Spec.TLS = instance.Spec.DesignateAPI.TLS
 		deployment.Spec.TransportURLSecret = instance.Status.TransportURLSecret
 		deployment.Spec.NodeSelector = instance.Spec.DesignateAPI.NodeSelector
+		deployment.Spec.APITimeout = instance.Spec.APITimeout
 
 		err := controllerutil.SetControllerReference(instance, deployment, r.Scheme)
 		if err != nil {

--- a/controllers/designateapi_controller.go
+++ b/controllers/designateapi_controller.go
@@ -1103,6 +1103,7 @@ func (r *DesignateAPIReconciler) generateServiceConfigMaps(
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
 	templateParameters["KeystoneInternalURL"] = keystoneInternalURL
 	templateParameters["KeystonePublicURL"] = keystonePublicURL
+	templateParameters["TimeOut"] = instance.Spec.APITimeout
 
 	// create httpd  vhost template parameters
 	httpdVhostConfig := map[string]interface{}{}

--- a/templates/designateapi/config/httpd.conf
+++ b/templates/designateapi/config/httpd.conf
@@ -23,6 +23,8 @@ SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
 
+TimeOut {{ $.TimeOut }}
+
 {{ range $endpt, $vhost := .VHosts }}
   # {{ $endpt }} vhost {{ $vhost.ServerName }} configuration
   <VirtualHost *:9001>


### PR DESCRIPTION
This patch adds an apiTimeout field to the DesignateSpecCore to DesignateSpec, to allow a configuration of the timeouts for HAProxy and Apache.
Inherit from the controller in case it is not specified by the user.

Jira: https://issues.redhat.com/browse/OSPRH-10963