### PR TITLE
Make RedisServiceName optional and add listType annotations

### DIFF
--- a/api/bases/designate.openstack.org_designatecentrals.yaml
+++ b/api/bases/designate.openstack.org_designatecentrals.yaml
@@ -134,6 +134,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               replicas:
                 default: 1
                 description: Replicas - Designate Central Replicas

--- a/api/bases/designate.openstack.org_designateproducers.yaml
+++ b/api/bases/designate.openstack.org_designateproducers.yaml
@@ -133,6 +133,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               replicas:
                 default: 1
                 description: Replicas - Designate Producer Replicas

--- a/api/bases/designate.openstack.org_designates.yaml
+++ b/api/bases/designate.openstack.org_designates.yaml
@@ -706,6 +706,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   replicas:
                     default: 1
                     description: Replicas - Designate Central Replicas
@@ -1063,6 +1064,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   replicas:
                     default: 1
                     description: Replicas - Designate Producer Replicas
@@ -1548,7 +1550,6 @@ spec:
             - designateProducer
             - designateWorker
             - rabbitMqClusterName
-            - redisServiceName
             - secret
             type: object
           status:

--- a/api/v1beta1/designate_types.go
+++ b/api/v1beta1/designate_types.go
@@ -182,7 +182,7 @@ type DesignateSpecBase struct {
 	// DesignateNetworkAttachment is a NetworkAttachment resource name for the Designate Control Network
 	DesignateNetworkAttachment string `json:"designateNetworkAttachment"`
 
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="designate-redis"
 	// RedisServiceName is the name of the Redis instance to be used (must be in the same namespace as designate)
 	RedisServiceName string `json:"redisServiceName"`

--- a/api/v1beta1/designatecentral_types.go
+++ b/api/v1beta1/designatecentral_types.go
@@ -69,6 +69,7 @@ type DesignateCentralSpecBase struct {
 	TLS tls.Ca `json:"tls,omitempty"`
 
 	// List of Redis Host IP addresses
+	// +listType:=atomic
 	RedisHostIPs []string `json:"redisHostIPs,omitempty"`
 }
 

--- a/api/v1beta1/designateproducer_types.go
+++ b/api/v1beta1/designateproducer_types.go
@@ -69,6 +69,7 @@ type DesignateProducerSpecBase struct {
 	TLS tls.Ca `json:"tls,omitempty"`
 
 	// List of Redis Host IP addresses
+	// +listType:=atomic
 	RedisHostIPs []string `json:"redisHostIPs,omitempty"`
 }
 

--- a/config/crd/bases/designate.openstack.org_designatecentrals.yaml
+++ b/config/crd/bases/designate.openstack.org_designatecentrals.yaml
@@ -134,6 +134,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               replicas:
                 default: 1
                 description: Replicas - Designate Central Replicas

--- a/config/crd/bases/designate.openstack.org_designateproducers.yaml
+++ b/config/crd/bases/designate.openstack.org_designateproducers.yaml
@@ -133,6 +133,7 @@ spec:
                 items:
                   type: string
                 type: array
+                x-kubernetes-list-type: atomic
               replicas:
                 default: 1
                 description: Replicas - Designate Producer Replicas

--- a/config/crd/bases/designate.openstack.org_designates.yaml
+++ b/config/crd/bases/designate.openstack.org_designates.yaml
@@ -706,6 +706,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   replicas:
                     default: 1
                     description: Replicas - Designate Central Replicas
@@ -1063,6 +1064,7 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-list-type: atomic
                   replicas:
                     default: 1
                     description: Replicas - Designate Producer Replicas
@@ -1548,7 +1550,6 @@ spec:
             - designateProducer
             - designateWorker
             - rabbitMqClusterName
-            - redisServiceName
             - secret
             type: object
           status:


### PR DESCRIPTION
Since RedisServiceName has a default, lets make it optional. Parameters which are required with a default is a contradiction.

Also adds listType annotation to RedisHostIPs.