### PR TITLE
Fix pools.yaml rndc_key_file config typo

### DIFF
--- a/pkg/designate/generate_bind9_pools_yaml.go
+++ b/pkg/designate/generate_bind9_pools_yaml.go
@@ -58,11 +58,11 @@ type Master struct {
 }
 
 type Options struct {
-	Host           string `yaml:"host"`
-	Port           int    `yaml:"port"`
-	RNDCHost       string `yaml:"rndc_host"`
-	RNDCPort       int    `yaml:"rndc_port"`
-	RNDCConfigFile string `yaml:"rndc_config_file"`
+	Host        string `yaml:"host"`
+	Port        int    `yaml:"port"`
+	RNDCHost    string `yaml:"rndc_host"`
+	RNDCPort    int    `yaml:"rndc_port"`
+	RNDCKeyFile string `yaml:"rndc_key_file"`
 }
 
 type CatalogZone struct {
@@ -83,7 +83,7 @@ func GeneratePoolsYamlData(BindMap, MdnsMap, NsRecordsMap map[string]string) (st
 	// Create targets and nameservers
 	nameservers := []Nameserver{}
 	targets := []Target{}
-	rndcKeyNum := 1
+	rndcKeyNum := 0
 
 	for _, bindIP := range BindMap {
 		nameservers = append(nameservers, Nameserver{
@@ -104,11 +104,11 @@ func GeneratePoolsYamlData(BindMap, MdnsMap, NsRecordsMap map[string]string) (st
 			Description: fmt.Sprintf("BIND9 Server %d (%s)", rndcKeyNum, bindIP),
 			Masters:     masters,
 			Options: Options{
-				Host:           bindIP,
-				Port:           53,
-				RNDCHost:       bindIP,
-				RNDCPort:       953,
-				RNDCConfigFile: fmt.Sprintf("%s/%s-%d.conf", RndcConfDir, DesignateRndcKey, rndcKeyNum),
+				Host:        bindIP,
+				Port:        53,
+				RNDCHost:    bindIP,
+				RNDCPort:    953,
+				RNDCKeyFile: fmt.Sprintf("%s/%s-%d", RndcConfDir, DesignateRndcKey, rndcKeyNum),
 			},
 		}
 		targets = append(targets, target)

--- a/templates/designatepoolmanager/config/pools.yaml.tmpl
+++ b/templates/designatepoolmanager/config/pools.yaml.tmpl
@@ -35,7 +35,7 @@
         port: {{.Options.Port}}
         rndc_host: {{.Options.RNDCHost}}
         rndc_port: {{.Options.RNDCPort}}
-        rndc_config_file: {{.Options.RNDCConfigFile}}
+        rndc_key_file: {{.Options.RNDCKeyFile}}
     {{- end }}
 
   {{- if .CatalogZone }}

--- a/tests/functional/designate_controller_test.go
+++ b/tests/functional/designate_controller_test.go
@@ -680,7 +680,7 @@ var _ = Describe("Designate controller", func() {
 					Expect(target.Type).To(Equal("bind9"), "Only Bind9 is a supported Designate backend")
 
 					// Check description format
-					serverNum := i + 1
+					serverNum := i
 					expectedDesc := fmt.Sprintf("BIND9 Server %d (%s)", serverNum, target.Options.Host)
 					Expect(target.Description).To(Equal(expectedDesc), "Target description format mismatch")
 
@@ -712,8 +712,8 @@ var _ = Describe("Designate controller", func() {
 					Expect(target.Options.RNDCPort).To(BeNumerically(">", 0), "RNDC port should be a positive number")
 
 					// Validate RNDC config file path
-					expectedRndcPath := fmt.Sprintf("/etc/designate/rndc-keys/rndc-key-%d.conf", serverNum)
-					Expect(target.Options.RNDCConfigFile).To(Equal(expectedRndcPath), "RNDC config file path mismatch")
+					expectedRndcPath := fmt.Sprintf("/etc/designate/rndc-keys/rndc-key-%d", serverNum)
+					Expect(target.Options.RNDCKeyFile).To(Equal(expectedRndcPath), "RNDC config file path mismatch")
 				}
 
 				// Validate len(nameservers) == len(hosts) - which are all Bind9 hosts


### PR DESCRIPTION
So far we were generating a pools.yaml file with rndc_config_file config option, but it should have been rndc_key_file, with the correct path.

This patch fixes it.