### PR TITLE
Expose unbound endpoints

### DIFF
--- a/api/bases/designate.openstack.org_designates.yaml
+++ b/api/bases/designate.openstack.org_designates.yaml
@@ -1174,6 +1174,9 @@ spec:
                 description: DesignateUnbound - Spec definition for the Unbound Resolver
                   service of this Designate deployment
                 properties:
+                  addressPool:
+                    description: AddressPool
+                    type: string
                   containerImage:
                     description: ContainerImage - Designate Container Image URL (will
                       be set to environmental default if empty)

--- a/api/bases/designate.openstack.org_designateunbounds.yaml
+++ b/api/bases/designate.openstack.org_designateunbounds.yaml
@@ -48,6 +48,9 @@ spec:
           spec:
             description: DesignateUnboundSpec defines the desired state of DesignateUnbound
             properties:
+              addressPool:
+                description: AddressPool
+                type: string
               containerImage:
                 description: ContainerImage - Designate Container Image URL (will
                   be set to environmental default if empty)

--- a/api/v1beta1/designateunbound_types.go
+++ b/api/v1beta1/designateunbound_types.go
@@ -50,6 +50,10 @@ type DesignateUnboundSpecBase struct {
 	// +kubebuilder:validation:Minimum=0
 	// Replicas - Designate Unbound Replicas
 	Replicas *int32 `json:"replicas"`
+
+	// +kubebuilder:validation:Optional
+	// AddressPool
+	AddressPool string `json:"addressPool"`
 }
 
 // DesignateUnboundStatus defines the observed state of DesignateUnbound

--- a/config/crd/bases/designate.openstack.org_designates.yaml
+++ b/config/crd/bases/designate.openstack.org_designates.yaml
@@ -1174,6 +1174,9 @@ spec:
                 description: DesignateUnbound - Spec definition for the Unbound Resolver
                   service of this Designate deployment
                 properties:
+                  addressPool:
+                    description: AddressPool
+                    type: string
                   containerImage:
                     description: ContainerImage - Designate Container Image URL (will
                       be set to environmental default if empty)

--- a/config/crd/bases/designate.openstack.org_designateunbounds.yaml
+++ b/config/crd/bases/designate.openstack.org_designateunbounds.yaml
@@ -48,6 +48,9 @@ spec:
           spec:
             description: DesignateUnboundSpec defines the desired state of DesignateUnbound
             properties:
+              addressPool:
+                description: AddressPool
+                type: string
               containerImage:
                 description: ContainerImage - Designate Container Image URL (will
                   be set to environmental default if empty)

--- a/pkg/designateunbound/service.go
+++ b/pkg/designateunbound/service.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package designateunbound
+
+import (
+	"fmt"
+
+	designatev1beta1 "github.com/openstack-k8s-operators/designate-operator/api/v1beta1"
+	labels "github.com/openstack-k8s-operators/lib-common/modules/common/labels"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	UnboundAppName = "designateunbound"
+)
+
+// CreateUnboundServices creates a service for each unbound pod
+func CreateUnboundServices(m *designatev1beta1.DesignateUnbound, replicas int32, addressPool string) []*corev1.Service {
+	services := make([]*corev1.Service, replicas)
+
+	for i := int32(0); i < replicas; i++ {
+		podName := fmt.Sprintf("%s-%d", m.Name, i)
+		services[i] = createSingleUnboundService(m, podName, addressPool)
+	}
+
+	return services
+}
+
+func createSingleUnboundService(m *designatev1beta1.DesignateUnbound, podName string, addressPool string) *corev1.Service {
+	labels := labels.GetLabels(m, UnboundAppName, map[string]string{
+		"owner": "designate",
+		"cr":    m.GetName(),
+		"app":   UnboundAppName,
+	})
+
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: m.Namespace,
+			Labels:    labels,
+			Annotations: map[string]string{
+				"metallb.universe.tf/address-pool": addressPool,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(m, designatev1beta1.GroupVersion.WithKind(UnboundAppName)),
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+			Selector: map[string]string{
+				"app":                                "unbound",
+				"statefulset.kubernetes.io/pod-name": podName,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "named-udp",
+					Port:     53,
+					Protocol: corev1.ProtocolUDP,
+				},
+				{
+					Name:     "named-tcp",
+					Port:     53,
+					Protocol: corev1.ProtocolTCP,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
This patch creates series of services and map them to the statefulset members using the podname.

Each service has an IP from a metallb pool.