### PR TITLE
Remove redis sample file from config samples

### DIFF
--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,5 +1,4 @@
 ## Append samples you want in your CSV to this file as resources ##
 resources:
 - designate_v1beta1_designate.yaml
-- designate_redis.yaml
 #+kubebuilder:scaffold:manifestskustomizesamples

--- a/tests/kuttl/tests/basic/01-deploy-designate.yaml
+++ b/tests/kuttl/tests/basic/01-deploy-designate.yaml
@@ -3,7 +3,7 @@ kind: TestStep
 commands:
   - script: |
       cp ../../../../config/samples/designate_v1beta1_designate.yaml deploy
-      cp ../../../../config/samples/designate_redis.yaml deploy
+      cp redis.yaml deploy
       cp ../../../../demo/examples/ns_records/ns_records_CR_example.yaml deploy
       # Do not modify the designate network attachment if it already
       # exists.

--- a/tests/kuttl/tests/basic/deploy/kustomization.yaml
+++ b/tests/kuttl/tests/basic/deploy/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
 - ./designate_nad.yaml
 - ./designate_v1beta1_designate.yaml
-- ./designate_redis.yaml
+- ./redis.yaml

--- a/tests/kuttl/tests/basic/redis.yaml
+++ b/tests/kuttl/tests/basic/redis.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: redis.openstack.org/v1beta1
 kind: Redis
 metadata:

--- a/tests/kuttl/tests/designate_scale/00-test-resources.yaml
+++ b/tests/kuttl/tests/designate_scale/00-test-resources.yaml
@@ -4,3 +4,4 @@ commands:
   - script: |
       cp ../../common/designate_nad.yaml .
       oc apply -n $NAMESPACE -f designate_nad.yaml
+      oc apply -n $NAMESPACE -f redis.yaml

--- a/tests/kuttl/tests/designate_scale/redis.yaml
+++ b/tests/kuttl/tests/designate_scale/redis.yaml
@@ -1,9 +1,7 @@
+---
 apiVersion: redis.openstack.org/v1beta1
 kind: Redis
 metadata:
   name: designate-redis
 spec:
   replicas: 1
-  tls:
-    secretName: cert-designate-redis-svc
-    caBundleSecretName: combined-ca-bundle


### PR DESCRIPTION
This directory is used for creating CSV sample annotations, so redis related CRs don't belong here. redis CR for the purposes of testing are moved to the kuttl tests directories.