### PR TITLE
Update envvar name for netutils container image

### DIFF
--- a/api/v1beta1/designate_types.go
+++ b/api/v1beta1/designate_types.go
@@ -324,7 +324,7 @@ func SetupDefaults() {
 		WorkerContainerImageURL:       util.GetEnvVar("RELATED_IMAGE_DESIGNATE_WORKER_IMAGE_URL_DEFAULT", DesignateWorkerContainerImage),
 		UnboundContainerImageURL:      util.GetEnvVar("RELATED_IMAGE_DESIGNATE_UNBOUND_IMAGE_URL_DEFAULT", DesignateUnboundContainerImage),
 		Backendbind9ContainerImageURL: util.GetEnvVar("RELATED_IMAGE_DESIGNATE_BACKENDBIND9_IMAGE_URL_DEFAULT", DesignateBackendbind9ContainerImage),
-		NetUtilsURL:                   util.GetEnvVar("RELATED_IMAGE_NETUTILS_IMAGE_URL_DEFAULT", NetUtilsContainerImage),
+		NetUtilsURL:                   util.GetEnvVar("RELATED_IMAGE_NET_UTILS_IMAGE_URL_DEFAULT", NetUtilsContainerImage),
 		DesignateAPIRouteTimeout:      APITimeout,
 	}
 

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -25,5 +25,5 @@ spec:
           value: quay.io/podified-antelope-centos9/openstack-designate-backend-bind9:current-podified
         - name: RELATED_IMAGE_DESIGNATE_UNBOUND_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-unbound:current-podified
-        - name: RELATED_IMAGE_NETUTILS_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_NET_UTILS_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-netutils:current-podified


### PR DESCRIPTION
There is a env-var->go-var transform in openstack-operator that matches env vars to go vars based on _ breaks in the name. Our spec wants NetUtilsImage which requires NET_UTILS_IMAGE, not NETUTILS_IMAGE to get the correct camel case. This patch keeps things consistent across the repos.