### PR TITLE
Do not use MustParse to process PVC size

### DIFF
--- a/controllers/designatebackendbind9_controller.go
+++ b/controllers/designatebackendbind9_controller.go
@@ -600,7 +600,10 @@ func (r *DesignateBackendbind9Reconciler) reconcileNormal(ctx context.Context, i
 	//
 
 	// Define a new StatefulSet object
-	deplDef := designatebackendbind9.StatefulSet(instance, inputHash, serviceLabels, serviceAnnotations, topology)
+	deplDef, err := designatebackendbind9.StatefulSet(instance, inputHash, serviceLabels, serviceAnnotations, topology)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	depl := statefulset.NewStatefulSet(
 		deplDef,
 		time.Duration(5)*time.Second,


### PR DESCRIPTION
The `resource.MustParse` function was previously used by the operator to process the `storageSize` request provided by the top-level CR. However, even though `defer()` and `recover()` can be used to handle the `panic()` generated by that function in case of a wrong user input, that approach doesn't seem to work properly and the operator crashes without any chance to recover. The `ParseQuantity` implementation returns an error instead of `panic()`, and it can be easily caught at the operator level. This change moves away from the `MustParse` usage and relies on the `ParseQuantity` mechanism.