### PR TITLE
Add support to NsRecords via CR

### DIFF
--- a/pkg/designate/const.go
+++ b/pkg/designate/const.go
@@ -43,6 +43,8 @@ const (
 
 	NsRecordsConfigMap = "designate-ns-records-params"
 
+	NsRecordsCRContent = "designate-ns-records"
+
 	BindPredIPConfigMap = "designate-bind-ip-map"
 
 	RndcConfDir = "/etc/designate/rndc-keys"

--- a/pkg/designate/generate_bind9_pools_yaml.go
+++ b/pkg/designate/generate_bind9_pools_yaml.go
@@ -25,23 +25,25 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	designatev1 "github.com/openstack-k8s-operators/designate-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 )
 
 type Pool struct {
-	Name        string            `yaml:"name"`
-	Description string            `yaml:"description"`
-	Attributes  map[string]string `yaml:"attributes"`
-	NSRecords   []NSRecord        `yaml:"ns_records"`
-	Nameservers []Nameserver      `yaml:"nameservers"`
-	Targets     []Target          `yaml:"targets"`
-	CatalogZone *CatalogZone      `yaml:"catalog_zone,omitempty"` // it is a pointer because it is optional
+	Name        string                          `yaml:"name"`
+	Description string                          `yaml:"description"`
+	Attributes  map[string]string               `yaml:"attributes"`
+	NSRecords   []designatev1.DesignateNSRecord `yaml:"ns_records"`
+	Nameservers []Nameserver                    `yaml:"nameservers"`
+	Targets     []Target                        `yaml:"targets"`
+	CatalogZone *CatalogZone                    `yaml:"catalog_zone,omitempty"` // it is a pointer because it is optional
 }
 
-type NSRecord struct {
-	Hostname string `yaml:"hostname"`
-	Priority int    `yaml:"priority"`
-}
+// We have the same defined in the API now
+// type NSRecord struct {
+// 	Hostname string `yaml:"hostname"`
+// 	Priority int    `yaml:"priority"`
+// }
 
 type Nameserver struct {
 	Host string `yaml:"host"`
@@ -74,14 +76,7 @@ type CatalogZone struct {
 }
 
 // We sort all pool resources to get the correct hash every time
-func GeneratePoolsYamlDataAndHash(BindMap, MdnsMap, NsRecordsMap map[string]string) (string, string, error) {
-	nsRecords := []NSRecord{}
-	for _, data := range NsRecordsMap {
-		err := yaml.Unmarshal([]byte(data), &nsRecords)
-		if err != nil {
-			return "", "", fmt.Errorf("error unmarshalling yaml: %w", err)
-		}
-	}
+func GeneratePoolsYamlDataAndHash(BindMap, MdnsMap map[string]string, nsRecords []designatev1.DesignateNSRecord) (string, string, error) {
 	sort.Slice(nsRecords, func(i, j int) bool {
 		if nsRecords[i].Hostname != nsRecords[j].Hostname {
 			return nsRecords[i].Hostname < nsRecords[j].Hostname

--- a/tests/functional/designate_controller_test.go
+++ b/tests/functional/designate_controller_test.go
@@ -776,10 +776,21 @@ var _ = Describe("Designate controller", func() {
 			nsRecordsConfigMap := th.GetConfigMap(types.NamespacedName{
 				Name:      designate.NsRecordsConfigMap,
 				Namespace: namespace})
-			_, poolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, nsRecordsConfigMap.Data)
+
+			var allNSRecords []designatev1.DesignateNSRecord
+			for _, data := range nsRecordsConfigMap.Data {
+				var nsRecords []designatev1.DesignateNSRecord
+				err := yaml.Unmarshal([]byte(data), &nsRecords)
+				Expect(err).ToNot(HaveOccurred())
+				allNSRecords = append(allNSRecords, nsRecords...)
+			}
+
+			_, poolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, allNSRecords)
 			Expect(err).ToNot(HaveOccurred())
+
+			// we used to have inconsistent ordering, so generate the pools.yaml 10 times and make sure it is has exactly the same content
 			for i := 0; i < 10; i++ {
-				_, newPoolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, nsRecordsConfigMap.Data)
+				_, newPoolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, allNSRecords)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(poolsYamlHash).Should(Equal(newPoolsYamlHash))
 			}


### PR DESCRIPTION
So far we only allowed using NsRecords via a ConfigMap.

While using nsRecordsConfigMap works, creating/modifying it does not trigger another run of the reconciliation loop. That means the user can modify the ns records config map and wait for a long time without the changes to take affect from Designate perspective.

This patch adds support for adding nsRecords via Designate CR/csv, which will take precedence over the ns records config map. If nsRecords is not configured in the Designate CR, it will fall back to the configmap.