### PR TITLE
[OSPRH-14758] Fix controlNetworkName requires default value

### DIFF
--- a/controllers/designate_controller.go
+++ b/controllers/designate_controller.go
@@ -1665,6 +1665,12 @@ func (r *DesignateReconciler) mdnsStatefulSetCreateOrUpdate(ctx context.Context,
 		statefulSet.Spec.NodeSelector = instance.Spec.DesignateMdns.NodeSelector
 		statefulSet.Spec.TopologyRef = instance.Spec.DesignateMdns.TopologyRef
 
+		networkAttachment := "designate"
+		if instance.Spec.DesignateNetworkAttachment != "" {
+			networkAttachment = instance.Spec.DesignateNetworkAttachment
+		}
+		statefulSet.Spec.ControlNetworkName = networkAttachment
+
 		err := controllerutil.SetControllerReference(instance, statefulSet, r.Scheme)
 		if err != nil {
 			return err
@@ -1748,6 +1754,12 @@ func (r *DesignateReconciler) backendbind9StatefulSetCreateOrUpdate(ctx context.
 		statefulSet.Spec.ServiceAccount = instance.RbacResourceName()
 		statefulSet.Spec.NodeSelector = instance.Spec.DesignateBackendbind9.NodeSelector
 		statefulSet.Spec.TopologyRef = instance.Spec.DesignateBackendbind9.TopologyRef
+
+		networkAttachment := "designate"
+		if instance.Spec.DesignateNetworkAttachment != "" {
+			networkAttachment = instance.Spec.DesignateNetworkAttachment
+		}
+		statefulSet.Spec.ControlNetworkName = networkAttachment
 
 		err := controllerutil.SetControllerReference(instance, statefulSet, r.Scheme)
 		if err != nil {


### PR DESCRIPTION
So far we did not have a default value for controlNetworkName, which resulted in Designate network attachment not being found in some deployments.

This patch adds a hard-coded default value for Designate network attachment in case one was not defined in the CR.