### PR TITLE
Do not update status when reconciler exits due to panic

### DIFF
--- a/controllers/designate_controller.go
+++ b/controllers/designate_controller.go
@@ -174,6 +174,11 @@ func (r *DesignateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if r := recover(); r != nil {
+			Log.Info(fmt.Sprintf("Panic during reconcile %v\n", r))
+			panic(r)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {

--- a/controllers/designateapi_controller.go
+++ b/controllers/designateapi_controller.go
@@ -162,6 +162,11 @@ func (r *DesignateAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if r := recover(); r != nil {
+			Log.Info(fmt.Sprintf("Panic during reconcile %v\n", r))
+			panic(r)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {

--- a/controllers/designatebackendbind9_controller.go
+++ b/controllers/designatebackendbind9_controller.go
@@ -141,6 +141,11 @@ func (r *DesignateBackendbind9Reconciler) Reconcile(ctx context.Context, req ctr
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if rc := recover(); rc != nil {
+			r.Log.Info(fmt.Sprintf("Panic during reconcile %v\n", rc))
+			panic(rc)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {

--- a/controllers/designatecentral_controller.go
+++ b/controllers/designatecentral_controller.go
@@ -146,6 +146,11 @@ func (r *DesignateCentralReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if r := recover(); r != nil {
+			Log.Info(fmt.Sprintf("Panic during reconcile %v\n", r))
+			panic(r)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {

--- a/controllers/designatemdns_controller.go
+++ b/controllers/designatemdns_controller.go
@@ -145,6 +145,11 @@ func (r *DesignateMdnsReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if rc := recover(); rc != nil {
+			r.Log.Info(fmt.Sprintf("Panic during reconcile %v\n", rc))
+			panic(rc)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {

--- a/controllers/designateproducer_controller.go
+++ b/controllers/designateproducer_controller.go
@@ -145,6 +145,11 @@ func (r *DesignateProducerReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if r := recover(); r != nil {
+			Log.Info(fmt.Sprintf("Panic during reconcile %v\n", r))
+			panic(r)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {

--- a/controllers/designateunbound_controller.go
+++ b/controllers/designateunbound_controller.go
@@ -117,6 +117,11 @@ func (r *UnboundReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if rc := recover(); rc != nil {
+			r.Log.Info(fmt.Sprintf("Panic during reconcile %v\n", rc))
+			panic(rc)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {

--- a/controllers/designateworker_controller.go
+++ b/controllers/designateworker_controller.go
@@ -145,6 +145,11 @@ func (r *DesignateWorkerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if r := recover(); r != nil {
+			Log.Info(fmt.Sprintf("Panic during reconcile %v\n", r))
+			panic(r)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {


### PR DESCRIPTION
Currently we use deferred call to always update the status field when Reconciler call exits, which seems correct for any other error except Reconciler exits due to panic.

This change adds a call to recover function and try to handle panic and log error.

Closes: [OSPRH-16954](https://issues.redhat.com//browse/OSPRH-16954)