### PR TITLE
Migrate Designate Operator to uwsgi

### DIFF
--- a/templates/designateapi/bin/init.sh
+++ b/templates/designateapi/bin/init.sh
@@ -39,3 +39,6 @@ done
 # NOTE:dkehn - REMOVED because Kolla_set & start copy eveyrthing.
 # I'm doing this to get the designate.conf w/all the tags with values.
 cp -a ${SVC_CFG_MERGED} ${SVC_CFG}
+
+echo "Starting Apache"
+/usr/sbin/httpd -DFOREGROUND &

--- a/templates/designateapi/config/designate-api-config.json
+++ b/templates/designateapi/config/designate-api-config.json
@@ -1,5 +1,5 @@
 {
-    "command": "/usr/sbin/httpd -DFOREGROUND",
+    "command": "/usr/bin/uwsgi --ini /etc/designate/designate-api-uwsgi.ini",
     "config_files": [
         {
             "source": "/var/lib/config-data/merged/designate.conf",
@@ -30,6 +30,12 @@
             "dest": "/etc/httpd/conf.d/ssl.conf",
             "owner": "root",
             "perm": "0644"
+        },
+        {
+            "source": "/var/lib/config-data/merged/designate-api-uwsgi.ini",
+            "dest": "/etc/designate/designate-api-uwsgi.ini",
+            "owner": "designate",
+            "perm": "0600"
         },
         {
             "source": "/var/lib/config-data/tls/certs/*",

--- a/templates/designateapi/config/designate-api-uwsgi.ini
+++ b/templates/designateapi/config/designate-api-uwsgi.ini
@@ -1,0 +1,19 @@
+# copied from our u/s jobs, we probably need to change some config options here
+[uwsgi]
+http-socket = 127.0.0.1:60053
+chmod-socket = 666
+socket = /var/run/uwsgi/designate-api-wsgi.socket
+start-time = %t
+lazy-apps = true
+add-header = Connection: close
+buffer-size = 65535
+hook-master-start = unix_signal:15 gracefully_kill_them_all
+thunder-lock = true
+plugins = http,python3
+enable-threads = true
+worker-reload-mercy = 80
+exit-on-reload = false
+die-on-term = true
+master = true
+processes = 2
+module = designate.wsgi.api:application

--- a/templates/designateapi/config/httpd.conf
+++ b/templates/designateapi/config/httpd.conf
@@ -46,11 +46,8 @@ TimeOut {{ $.TimeOut }}
     SSLCertificateKeyFile   "{{ $vhost.SSLCertificateKeyFile }}"
     {{- end }}
 
-    ## WSGI configuration
-    WSGIProcessGroup {{ $endpt }}
-    WSGIApplicationGroup %{GLOBAL}
-    WSGIPassAuthorization On
-    WSGIDaemonProcess {{ $endpt }} processes=5 threads=1 user=designate group=designate display-name={{ $endpt }}
-    WSGIScriptAlias / "/usr/bin/designate-api-wsgi"
+    # ProxyPass configuration for uwsgi
+    ProxyPass "/dns" "http://127.0.0.1:60053" retry=0
+
   </VirtualHost>
 {{ end }}


### PR DESCRIPTION
mod_wsgi is being removed from upstream sources but OpenStack APIs are still using it downstream, which is very concerning.

This patch aims to replace mod_wsgi with uwsgi.

Depends-On: https://github.com/openstack-k8s-operators/tcib/pull/282