### PR TITLE
18.0 fr3 Set the listen address to the predictable IP for mdns

### DIFF
--- a/templates/common/setipalias.py
+++ b/templates/common/setipalias.py
@@ -7,35 +7,35 @@ from pyroute2 import IPRoute
 
 mapping_prefix =  os.environ.get("MAP_PREFIX")
 if not len(mapping_prefix):
-    print(f"{sys.argv[0]} requires MAP_PREFIX to be set in environment variables")
+    print(f"{sys.argv[0]} requires MAP_PREFIX to be set in environment variables", file=sys.stderr)
     sys.exit(1)
 
-print(f"Using {mapping_prefix} as the map prefix")
+print(f"Using {mapping_prefix} as the map prefix", file=sys.stderr)
 
 nodefile = ""
 podname = os.environ.get("POD_NAME").strip()
 if not len(podname):
-    print(f"{sys.argv[0]} requires POD_NAME in environment variables")
+    print(f"{sys.argv[0]} requires POD_NAME in environment variables", file=sys.stderr)
     sys.exit(1)
 
-print(f"Pod name is {podname}")
+print(f"Pod name is {podname}", file=sys.stderr)
 namepieces = podname.split('-')
 pod_index = namepieces[-1]
 nodefile = f"{mapping_prefix}{pod_index}"
 
 interface_name = os.environ.get("NAD_NAME", "designate").strip()
 
-print(f"working with address file {nodefile}")
+print(f"working with address file {nodefile}", file=sys.stderr)
 filename = os.path.join('/var/lib/predictableips', nodefile)
 if not os.path.exists(filename):
-    print(f"Required alias address file {filename} does not exist")
+    print(f"Required alias address file {filename} does not exist", file=sys.stderr)
     sys.exit(1)
 
 ip = IPRoute()
 designateinterface = ip.link_lookup(ifname=interface_name)
 
 if not len(designateinterface):
-    print(f"{interface_name} attachment not present")
+    print(f"{interface_name} attachment not present", file=sys.stderr)
     sys.exit(1)
 
 
@@ -44,7 +44,9 @@ ipaddr = ipfile.read()
 ipfile.close()
 
 if ipaddr:
-    print(f"Setting {ipaddr} on {interface_name}")
+    print(f"Setting {ipaddr} on {interface_name}", file=sys.stderr)
+    # output the ipaddr to stdout so that the container-scripts/setipalias.sh can read it
+    print(f"{ipaddr}")
     # Get our current addresses so we can avoid trying to set the
     # same address again.
     version = ipaddress.ip_address(ipaddr).version
@@ -57,6 +59,6 @@ if ipaddr:
             mask_value = 128
         ip.addr('add', index = designateinterface[0], address=ipaddr, mask=mask_value)
 else:
-    print('No IP address found')
+    print('No IP address found', file=sys.stderr)
 
 ip.close()

--- a/templates/designatemdns/bin/setipalias.sh
+++ b/templates/designatemdns/bin/setipalias.sh
@@ -18,5 +18,9 @@ set -ex
 # expect that the common.sh is in the same dir as the calling script
 #
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+SVC_CFG_MERGED=/var/lib/config-data/merged/designate.conf
 
-/usr/local/bin/container-scripts/setipalias.py
+IPADDR=$(/usr/local/bin/container-scripts/setipalias.py)
+if [ $? -eq 0 ] && [ -n "$IPADDR" ]; then
+    crudini --set $SVC_CFG_MERGED 'service:mdns' 'listen' "${IPADDR}:5354"
+fi


### PR DESCRIPTION
Have mDNS listen and use the predictable IP for apps expecting replies from mDNS to be from the same address that was used for the request.

Jira: [OSPRH-15638](https://issues.redhat.com//browse/OSPRH-15638)