### PR TITLE
18.0 fr3 Disable RBAC checks temporarily

### DIFF
--- a/templates/designate/config/designate.conf
+++ b/templates/designate/config/designate.conf
@@ -20,8 +20,8 @@ topics=notifications
 driver=messagingv2
 
 [oslo_policy]
-enforce_scope=True
-enforce_new_defaults=True
+enforce_scope=False
+enforce_new_defaults=False
 
 [coordination]
 backend_url={{ .CoordinationBackendURL }}


### PR DESCRIPTION
We need to disable RBAC for now as the operator had several configuration challenges that prevented distributing policy.json updates. This commit can be reverted once that has been resolved.