### PR TITLE
DNM: test openstack must gather

### DIFF
--- a/controllers/designate_controller.go
+++ b/controllers/designate_controller.go
@@ -397,6 +397,7 @@ func (r *DesignateReconciler) reconcileInit(
 	serviceLabels map[string]string,
 	serviceAnnotations map[string]string,
 ) (ctrl.Result, error) {
+	// test
 	Log := r.GetLogger(ctx)
 
 	Log.Info(fmt.Sprintf("Reconciling Service '%s' init", instance.Name))


### PR DESCRIPTION
We recently merged a PR that fixed get_desigate_status in openstack must gather. I am uploading this PR to search for that function output in the PR artifacts.