### PR TITLE
Don't update pool update hash until job is successful

### DIFF
--- a/controllers/designate_controller.go
+++ b/controllers/designate_controller.go
@@ -887,15 +887,8 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 		if oldHash != poolsYamlHash {
 			Log.Info(fmt.Sprintf("Old poolsYamlHash %s is different than new poolsYamlHash %s.\nLaunching pool update job", oldHash, poolsYamlHash))
 
-			instance.Status.Hash[designatev1beta1.PoolUpdateHash] = poolsYamlHash
-			if err := r.Client.Status().Update(ctx, instance); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to update status hash: %w", err)
-			}
-
 			jobDef := designate.PoolUpdateJob(instance, serviceLabels, serviceAnnotations)
-
 			Log.Info("Initializing pool update job")
-
 			poolUpdatejob := job.NewJob(
 				jobDef,
 				designatev1beta1.PoolUpdateHash,
@@ -909,6 +902,7 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 				return ctrl.Result{}, err
 			}
 			Log.Info("Pool update job completed successfully")
+			instance.Status.Hash[designatev1beta1.PoolUpdateHash] = poolsYamlHash
 		}
 	}
 


### PR DESCRIPTION
Fixes a bug where we update a hash before the job that it is supposed to trigger the poolupdatejob before it succeeds making the controller skip further attempts. This leads to a broken internal configuration in designate that won't be rectified until something changes the contents of a the pools.yaml file like scaling changes for mDNS or the BIND9 instances or the values in nsRecords.