### PR TITLE
Use structured logging

### DIFF
--- a/controllers/designateapi_controller.go
+++ b/controllers/designateapi_controller.go
@@ -399,7 +399,7 @@ func (r *DesignateAPIReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 func (r *DesignateAPIReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("DesignateAPI")
+	Log := r.GetLogger(ctx)
 
 	allWatchFields := []string{
 		passwordSecretField,
@@ -417,12 +417,12 @@ func (r *DesignateAPIReconciler) findObjectsForSrc(ctx context.Context, src clie
 		}
 		err := r.Client.List(context.TODO(), crList, listOps)
 		if err != nil {
-			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			Log.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
 			return requests
 		}
 
 		for _, item := range crList.Items {
-			l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+			Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 			requests = append(requests,
 				reconcile.Request{
@@ -441,7 +441,7 @@ func (r *DesignateAPIReconciler) findObjectsForSrc(ctx context.Context, src clie
 func (r *DesignateAPIReconciler) findObjectForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("DesignateAPI")
+	Log := r.GetLogger(ctx)
 
 	crList := &designatev1beta1.DesignateAPIList{}
 	listOps := &client.ListOptions{
@@ -449,12 +449,12 @@ func (r *DesignateAPIReconciler) findObjectForSrc(ctx context.Context, src clien
 	}
 	err := r.Client.List(ctx, crList, listOps)
 	if err != nil {
-		l.Error(err, fmt.Sprintf("listing %s for namespace: %s", crList.GroupVersionKind().Kind, src.GetNamespace()))
+		Log.Error(err, fmt.Sprintf("listing %s for namespace: %s", crList.GroupVersionKind().Kind, src.GetNamespace()))
 		return requests
 	}
 
 	for _, item := range crList.Items {
-		l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+		Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 		requests = append(requests,
 			reconcile.Request{

--- a/controllers/designatecentral_controller.go
+++ b/controllers/designatecentral_controller.go
@@ -345,7 +345,7 @@ func (r *DesignateCentralReconciler) SetupWithManager(ctx context.Context, mgr c
 func (r *DesignateCentralReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("DesignateCentral")
+	Log := r.GetLogger(ctx)
 
 	allWatchFields := []string{
 		passwordSecretField,
@@ -361,12 +361,12 @@ func (r *DesignateCentralReconciler) findObjectsForSrc(ctx context.Context, src 
 		}
 		err := r.Client.List(context.TODO(), crList, listOps)
 		if err != nil {
-			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			Log.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
 			return requests
 		}
 
 		for _, item := range crList.Items {
-			l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+			Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 			requests = append(requests,
 				reconcile.Request{

--- a/controllers/designateproducer_controller.go
+++ b/controllers/designateproducer_controller.go
@@ -352,7 +352,7 @@ func (r *DesignateProducerReconciler) SetupWithManager(ctx context.Context, mgr 
 func (r *DesignateProducerReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("DesignateProducer")
+	Log := r.GetLogger(ctx)
 
 	allWatchFields := []string{
 		passwordSecretField,
@@ -368,12 +368,12 @@ func (r *DesignateProducerReconciler) findObjectsForSrc(ctx context.Context, src
 		}
 		err := r.Client.List(context.TODO(), crList, listOps)
 		if err != nil {
-			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			Log.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
 			return requests
 		}
 
 		for _, item := range crList.Items {
-			l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+			Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 			requests = append(requests,
 				reconcile.Request{

--- a/controllers/designateworker_controller.go
+++ b/controllers/designateworker_controller.go
@@ -353,7 +353,7 @@ func (r *DesignateWorkerReconciler) SetupWithManager(ctx context.Context, mgr ct
 func (r *DesignateWorkerReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(ctx).WithName("Controllers").WithName("DesignateWorker")
+	Log := r.GetLogger(ctx)
 
 	allWatchFields := []string{
 		passwordSecretField,
@@ -369,12 +369,12 @@ func (r *DesignateWorkerReconciler) findObjectsForSrc(ctx context.Context, src c
 		}
 		err := r.Client.List(context.TODO(), crList, listOps)
 		if err != nil {
-			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			Log.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
 			return requests
 		}
 
 		for _, item := range crList.Items {
-			l.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
+			Log.Info(fmt.Sprintf("input source %s changed, reconcile: %s - %s", src.GetName(), item.GetName(), item.GetNamespace()))
 
 			requests = append(requests,
 				reconcile.Request{

--- a/main.go
+++ b/main.go
@@ -192,7 +192,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(context.Background(), mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DesignateMdns")
 		os.Exit(1)
 	}
@@ -202,8 +202,7 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("DesignateBackendbind9"),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(context.Background(), mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DesignateBackendbind9")
 		os.Exit(1)
 	}
@@ -213,7 +212,6 @@ func main() {
 		Client:  mgr.GetClient(),
 		Scheme:  mgr.GetScheme(),
 		Kclient: kclient,
-		Log:     ctrl.Log.WithName("controllers").WithName("DesignateUnbound"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DesignateUnbound")
 		os.Exit(1)

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -209,7 +209,7 @@ var _ = BeforeSuite(func() {
 		Client:  k8sManager.GetClient(),
 		Scheme:  k8sManager.GetScheme(),
 		Kclient: kclient,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(ctx, k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 	err = (&controllers.DesignateCentralReconciler{
 		Client:  k8sManager.GetClient(),


### PR DESCRIPTION
This change uses GetLogger instead of direct use of log.FromContext to support structured logging.