### PR TITLE
[golang] bump to golang 1.24

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: tools
   namespace: openstack-k8s-operators
-  tag: ci-build-root-golang-1.21-sdk-1.31
+  tag: ci-build-root-golang-1.24-sdk-1.31

--- a/.github/workflows/build-designate-operator.yaml
+++ b/.github/workflows/build-designate-operator.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/reusable-build-operator.yaml@main
     with:
       operator_name: designate
-      go_version: 1.21.x
+      go_version: 1.24.x
       operator_sdk_version: 1.31.0
     secrets:
       IMAGENAMESPACE: ${{ secrets.IMAGENAMESPACE }}

--- a/.github/workflows/force-bump-pr-manual.yaml
+++ b/.github/workflows/force-bump-pr-manual.yaml
@@ -9,5 +9,6 @@ jobs:
     with:
       operator_name: designate
       branch_name: ${{ github.ref_name }}
+      custom_image: quay.io/openstack-k8s-operators/openstack-k8s-operators-ci-build-tools:golang-1.24-sdk-1.31
     secrets:
       FORCE_BUMP_PULL_REQUEST_PAT: ${{ secrets.FORCE_BUMP_PULL_REQUEST_PAT }}

--- a/.github/workflows/force-bump-pr-scheduled.yaml
+++ b/.github/workflows/force-bump-pr-scheduled.yaml
@@ -10,5 +10,6 @@ jobs:
     uses: openstack-k8s-operators/openstack-k8s-operators-ci/.github/workflows/force-bump-branches.yaml@main
     with:
       operator_name: designate
+      custom_image: quay.io/openstack-k8s-operators/openstack-k8s-operators-ci-build-tools:golang-1.24-sdk-1.31
     secrets:
       FORCE_BUMP_PULL_REQUEST_PAT: ${{ secrets.FORCE_BUMP_PULL_REQUEST_PAT }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,10 +1,20 @@
+version: 2
+
 linters:
   # Enable specific linter
   # https://golangci-lint.run/usage/linters/#enabled-by-default
   enable:
     - errorlint
     - revive
-    - gofmt
+    - ginkgolinter
     - govet
+    - gosec
+    - errname
+    - err113
+
+formatters:
+  enable:
+    - gofmt
+
 run:
   timeout: 5m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
       entry: bashate --error . --ignore=E006,E040,E011,E020,E012
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.59.1
+  rev: v2.4.0
   hooks:
     - id: golangci-lint-full
       args: ["-v"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.21
+ARG GOLANG_BUILDER=registry.access.redhat.com/ubi9/go-toolset:1.24
 ARG OPERATOR_BASE_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 # Build the manager binary

--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,10 @@ tidy: ## Run go mod tidy on every mod file in the repo
 	go mod tidy
 	cd ./api && go mod tidy
 
+GOLANGCI_LINT_VERSION ?= v2.4.0
 .PHONY: golangci-lint
 golangci-lint:
-	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.59.1
+	test -s $(LOCALBIN)/golangci-lint || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
 	$(LOCALBIN)/golangci-lint run --fix --timeout=5m
 
 .PHONY: test
@@ -188,7 +189,7 @@ GINKGO ?= $(LOCALBIN)/ginkgo
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
 OPERATOR_SDK_VERSION ?= v1.31.0
-GOTOOLCHAIN_VERSION ?= go1.21.0
+GOTOOLCHAIN_VERSION ?= go1.24.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/designate-operator/api
 
-go 1.21
+go 1.24
 
 require (
 	github.com/onsi/ginkgo/v2 v2.20.1

--- a/controllers/designate_common.go
+++ b/controllers/designate_common.go
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package controllers implements the designate-operator Kubernetes controllers.
 package controllers
 
 import (

--- a/controllers/designate_controller.go
+++ b/controllers/designate_controller.go
@@ -181,7 +181,7 @@ func (r *DesignateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	// Fetch the Designate instance
 	instance := &designatev1beta1.Designate{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -282,7 +282,7 @@ func (r *DesignateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 // fields to index to reconcile when change
 const (
 	passwordSecretField     = ".spec.secret"
-	caBundleSecretNameField = ".spec.tls.caBundleSecretName"
+	caBundleSecretNameField = ".spec.tls.caBundleSecretName" // #nosec G101
 	tlsAPIInternalField     = ".spec.tls.api.internal.secretName"
 	tlsAPIPublicField       = ".spec.tls.api.public.secretName"
 	topologyField           = ".spec.topologyRef.Name"
@@ -311,7 +311,7 @@ func (r *DesignateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		listOpts := []client.ListOption{
 			client.InNamespace(o.GetNamespace()),
 		}
-		if err := r.Client.List(context.Background(), designates, listOpts...); err != nil {
+		if err := r.List(context.Background(), designates, listOpts...); err != nil {
 			Log.Error(err, "Unable to retrieve Designate CRs %v")
 			return nil
 		}
@@ -767,19 +767,19 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 	}
 
 	// Fetch allocated ips from Mdns and Bind config maps and store them in allocatedIPs
-	mdnsLabels := labels.GetLabels(instance, labels.GetGroupLabel(instance.ObjectMeta.Name), map[string]string{})
+	mdnsLabels := labels.GetLabels(instance, labels.GetGroupLabel(instance.Name), map[string]string{})
 	mdnsConfigMap, err := r.handleConfigMap(ctx, helper, instance, designate.MdnsPredIPConfigMap, mdnsLabels)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	bindLabels := labels.GetLabels(instance, labels.GetGroupLabel(instance.ObjectMeta.Name), map[string]string{})
+	bindLabels := labels.GetLabels(instance, labels.GetGroupLabel(instance.Name), map[string]string{})
 	bindConfigMap, err := r.handleConfigMap(ctx, helper, instance, designate.BindPredIPConfigMap, bindLabels)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	nsRecordsLabels := labels.GetLabels(instance, labels.GetGroupLabel(instance.ObjectMeta.Name), map[string]string{})
+	nsRecordsLabels := labels.GetLabels(instance, labels.GetGroupLabel(instance.Name), map[string]string{})
 	nsRecords, err := r.getNSRecords(ctx, helper, instance, nsRecordsLabels)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -1361,7 +1361,7 @@ func (r *DesignateReconciler) generateServiceConfigMaps(
 
 	// TLS handling
 	var tlsCfg *tls.Service
-	if instance.Spec.DesignateAPI.TLS.Ca.CaBundleSecretName != "" {
+	if instance.Spec.DesignateAPI.TLS.CaBundleSecretName != "" {
 		tlsCfg = &tls.Service{}
 	}
 
@@ -1443,7 +1443,7 @@ func (r *DesignateReconciler) generateServiceConfigMaps(
 	}
 
 	if len(redisIPs) == 0 {
-		err = fmt.Errorf("unable to configure designate deployment without Redis")
+		err = designate.ErrRedisRequired
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.InputReadyCondition,
 			condition.ErrorReason,
@@ -1900,7 +1900,7 @@ func (r *DesignateReconciler) checkDesignateAPIGeneration(
 	listOpts := []client.ListOption{
 		client.InNamespace(instance.Namespace),
 	}
-	if err := r.Client.List(context.Background(), api, listOpts...); err != nil {
+	if err := r.List(context.Background(), api, listOpts...); err != nil {
 		Log.Error(err, "Unable to retrieve DesignateAPI %w")
 		return false, err
 	}
@@ -1921,7 +1921,7 @@ func (r *DesignateReconciler) checkDesignateCentralGeneration(
 	listOpts := []client.ListOption{
 		client.InNamespace(instance.Namespace),
 	}
-	if err := r.Client.List(context.Background(), central, listOpts...); err != nil {
+	if err := r.List(context.Background(), central, listOpts...); err != nil {
 		Log.Error(err, "Unable to retrieve DesignateCentral %w")
 		return false, err
 	}
@@ -1942,7 +1942,7 @@ func (r *DesignateReconciler) checkDesignateWorkerGeneration(
 	listOpts := []client.ListOption{
 		client.InNamespace(instance.Namespace),
 	}
-	if err := r.Client.List(context.Background(), worker, listOpts...); err != nil {
+	if err := r.List(context.Background(), worker, listOpts...); err != nil {
 		Log.Error(err, "Unable to retrieve DesignateWorker %w")
 		return false, err
 	}
@@ -1963,7 +1963,7 @@ func (r *DesignateReconciler) checkDesignateMdnsGeneration(
 	listOpts := []client.ListOption{
 		client.InNamespace(instance.Namespace),
 	}
-	if err := r.Client.List(context.Background(), mdns, listOpts...); err != nil {
+	if err := r.List(context.Background(), mdns, listOpts...); err != nil {
 		Log.Error(err, "Unable to retrieve DesignateWorker %w")
 		return false, err
 	}
@@ -1984,7 +1984,7 @@ func (r *DesignateReconciler) checkDesignateProducerGeneration(
 	listOpts := []client.ListOption{
 		client.InNamespace(instance.Namespace),
 	}
-	if err := r.Client.List(context.Background(), prd, listOpts...); err != nil {
+	if err := r.List(context.Background(), prd, listOpts...); err != nil {
 		Log.Error(err, "Unable to retrieve DesignateProducer %w")
 		return false, err
 	}
@@ -2005,7 +2005,7 @@ func (r *DesignateReconciler) checkDesignateBindGeneration(
 	listOpts := []client.ListOption{
 		client.InNamespace(instance.Namespace),
 	}
-	if err := r.Client.List(context.Background(), prd, listOpts...); err != nil {
+	if err := r.List(context.Background(), prd, listOpts...); err != nil {
 		Log.Error(err, "Unable to retrieve DesignateBind %w")
 		return false, err
 	}
@@ -2026,7 +2026,7 @@ func (r *DesignateReconciler) checkDesignateUnboundGeneration(
 	listOpts := []client.ListOption{
 		client.InNamespace(instance.Namespace),
 	}
-	if err := r.Client.List(context.Background(), prd, listOpts...); err != nil {
+	if err := r.List(context.Background(), prd, listOpts...); err != nil {
 		Log.Error(err, "Unable to retrieve DesignateUnbound %w")
 		return false, err
 	}

--- a/controllers/designateapi_controller.go
+++ b/controllers/designateapi_controller.go
@@ -125,7 +125,7 @@ func (r *DesignateAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// Fetch the DesignateAPI instance
 	instance := &designatev1beta1.DesignateAPI{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -293,8 +293,8 @@ func (r *DesignateAPIReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 	}
 
 	svcSecretFn := func(ctx context.Context, o client.Object) []reconcile.Request {
-		var namespace string = o.GetNamespace()
-		var secretName string = o.GetName()
+		var namespace = o.GetNamespace()
+		var secretName = o.GetName()
 		result := []reconcile.Request{}
 
 		// get all API CRs
@@ -302,7 +302,7 @@ func (r *DesignateAPIReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 		listOpts := []client.ListOption{
 			client.InNamespace(namespace),
 		}
-		if err := r.Client.List(ctx, apis, listOpts...); err != nil {
+		if err := r.List(ctx, apis, listOpts...); err != nil {
 			Log.Error(err, "Unable to retrieve API CRs")
 			return nil
 		}
@@ -350,7 +350,7 @@ func (r *DesignateAPIReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 		listOpts := []client.ListOption{
 			client.InNamespace(o.GetNamespace()),
 		}
-		if err := r.Client.List(ctx, designateAPIs, listOpts...); err != nil {
+		if err := r.List(ctx, designateAPIs, listOpts...); err != nil {
 			Log.Error(err, "Unable to retrieve DesignateAPI CRs %v")
 			return nil
 		}
@@ -415,7 +415,7 @@ func (r *DesignateAPIReconciler) findObjectsForSrc(ctx context.Context, src clie
 			FieldSelector: fields.OneTermEqualSelector(field, src.GetName()),
 			Namespace:     src.GetNamespace(),
 		}
-		err := r.Client.List(context.TODO(), crList, listOps)
+		err := r.List(context.TODO(), crList, listOps)
 		if err != nil {
 			Log.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
 			return requests
@@ -447,7 +447,7 @@ func (r *DesignateAPIReconciler) findObjectForSrc(ctx context.Context, src clien
 	listOps := &client.ListOptions{
 		Namespace: src.GetNamespace(),
 	}
-	err := r.Client.List(ctx, crList, listOps)
+	err := r.List(ctx, crList, listOps)
 	if err != nil {
 		Log.Error(err, fmt.Sprintf("listing %s for namespace: %s", crList.GroupVersionKind().Kind, src.GetNamespace()))
 		return requests
@@ -760,7 +760,7 @@ func (r *DesignateAPIReconciler) reconcileNormal(ctx context.Context, instance *
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -784,7 +784,7 @@ func (r *DesignateAPIReconciler) reconcileNormal(ctx context.Context, instance *
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, err.Error())))
+					condition.TLSInputReadyWaitingMessage, err.Error()))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -1037,7 +1037,7 @@ func (r *DesignateAPIReconciler) reconcileNormal(ctx context.Context, instance *
 		if networkReady {
 			instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
 		} else {
-			err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachments)
+			err := fmt.Errorf("%w: %s", designate.ErrNetworkAttachmentConfig, instance.Spec.NetworkAttachments)
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.NetworkAttachmentsReadyCondition,
 				condition.ErrorReason,

--- a/controllers/designateproducer_controller.go
+++ b/controllers/designateproducer_controller.go
@@ -107,7 +107,7 @@ func (r *DesignateProducerReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Fetch the DesignateProducer instance
 	instance := &designatev1beta1.DesignateProducer{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -247,8 +247,8 @@ func (r *DesignateProducerReconciler) SetupWithManager(ctx context.Context, mgr 
 	}
 
 	svcSecretFn := func(_ context.Context, o client.Object) []reconcile.Request {
-		var namespace string = o.GetNamespace()
-		var secretName string = o.GetName()
+		var namespace = o.GetNamespace()
+		var secretName = o.GetName()
 		result := []reconcile.Request{}
 
 		// get all Producer CRs
@@ -256,7 +256,7 @@ func (r *DesignateProducerReconciler) SetupWithManager(ctx context.Context, mgr 
 		listOpts := []client.ListOption{
 			client.InNamespace(namespace),
 		}
-		if err := r.Client.List(context.Background(), apis, listOpts...); err != nil {
+		if err := r.List(context.Background(), apis, listOpts...); err != nil {
 			Log.Error(err, "Unable to retrieve Producer CRs %v")
 			return nil
 		}
@@ -301,7 +301,7 @@ func (r *DesignateProducerReconciler) SetupWithManager(ctx context.Context, mgr 
 		listOpts := []client.ListOption{
 			client.InNamespace(o.GetNamespace()),
 		}
-		if err := r.Client.List(context.Background(), apis, listOpts...); err != nil {
+		if err := r.List(context.Background(), apis, listOpts...); err != nil {
 			Log.Error(err, "Unable to retrieve Producer CRs %v")
 			return nil
 		}
@@ -366,7 +366,7 @@ func (r *DesignateProducerReconciler) findObjectsForSrc(ctx context.Context, src
 			FieldSelector: fields.OneTermEqualSelector(field, src.GetName()),
 			Namespace:     src.GetNamespace(),
 		}
-		err := r.Client.List(context.TODO(), crList, listOps)
+		err := r.List(context.TODO(), crList, listOps)
 		if err != nil {
 			Log.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
 			return requests
@@ -509,7 +509,7 @@ func (r *DesignateProducerReconciler) reconcileNormal(ctx context.Context, insta
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -570,7 +570,7 @@ func (r *DesignateProducerReconciler) reconcileNormal(ctx context.Context, insta
 	//
 
 	serviceLabels := map[string]string{
-		common.AppSelector:       instance.ObjectMeta.Name,
+		common.AppSelector:       instance.Name,
 		common.ComponentSelector: designateproducer.Component,
 	}
 
@@ -715,7 +715,7 @@ func (r *DesignateProducerReconciler) reconcileNormal(ctx context.Context, insta
 		if networkReady {
 			instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
 		} else {
-			err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachments)
+			err := fmt.Errorf("%w: %s", designate.ErrNetworkAttachmentConfig, instance.Spec.NetworkAttachments)
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.NetworkAttachmentsReadyCondition,
 				condition.ErrorReason,
@@ -785,7 +785,7 @@ func (r *DesignateProducerReconciler) generateServiceConfigMaps(
 	// - %-config-data configmap holding custom config for the service's designate.conf
 	//
 
-	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(instance.ObjectMeta.Name), map[string]string{})
+	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(instance.Name), map[string]string{})
 
 	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, h, designate.DatabaseName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {

--- a/controllers/designateworker_controller.go
+++ b/controllers/designateworker_controller.go
@@ -108,7 +108,7 @@ func (r *DesignateWorkerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Fetch the DesignateWorker instance
 	instance := &designatev1beta1.DesignateWorker{}
-	err := r.Client.Get(ctx, req.NamespacedName, instance)
+	err := r.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -248,8 +248,8 @@ func (r *DesignateWorkerReconciler) SetupWithManager(ctx context.Context, mgr ct
 	}
 
 	svcSecretFn := func(_ context.Context, o client.Object) []reconcile.Request {
-		var namespace string = o.GetNamespace()
-		var secretName string = o.GetName()
+		var namespace = o.GetNamespace()
+		var secretName = o.GetName()
 		result := []reconcile.Request{}
 
 		// get all Worker CRs
@@ -257,7 +257,7 @@ func (r *DesignateWorkerReconciler) SetupWithManager(ctx context.Context, mgr ct
 		listOpts := []client.ListOption{
 			client.InNamespace(namespace),
 		}
-		if err := r.Client.List(context.Background(), apis, listOpts...); err != nil {
+		if err := r.List(context.Background(), apis, listOpts...); err != nil {
 			Log.Error(err, "Unable to retrieve Worker CRs %v")
 			return nil
 		}
@@ -301,7 +301,7 @@ func (r *DesignateWorkerReconciler) SetupWithManager(ctx context.Context, mgr ct
 		listOpts := []client.ListOption{
 			client.InNamespace(o.GetNamespace()),
 		}
-		if err := r.Client.List(context.Background(), apis, listOpts...); err != nil {
+		if err := r.List(context.Background(), apis, listOpts...); err != nil {
 			Log.Error(err, "Unable to retrieve Worker CRs %v")
 			return nil
 		}
@@ -367,7 +367,7 @@ func (r *DesignateWorkerReconciler) findObjectsForSrc(ctx context.Context, src c
 			FieldSelector: fields.OneTermEqualSelector(field, src.GetName()),
 			Namespace:     src.GetNamespace(),
 		}
-		err := r.Client.List(context.TODO(), crList, listOps)
+		err := r.List(context.TODO(), crList, listOps)
 		if err != nil {
 			Log.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
 			return requests
@@ -509,7 +509,7 @@ func (r *DesignateWorkerReconciler) reconcileNormal(ctx context.Context, instanc
 					condition.TLSInputReadyCondition,
 					condition.RequestedReason,
 					condition.SeverityInfo,
-					fmt.Sprintf(condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName)))
+					condition.TLSInputReadyWaitingMessage, instance.Spec.TLS.CaBundleSecretName))
 				return ctrl.Result{}, nil
 			}
 			instance.Status.Conditions.Set(condition.FalseCondition(
@@ -533,7 +533,7 @@ func (r *DesignateWorkerReconciler) reconcileNormal(ctx context.Context, instanc
 	//
 
 	serviceLabels := map[string]string{
-		common.AppSelector:       instance.ObjectMeta.Name,
+		common.AppSelector:       instance.Name,
 		common.ComponentSelector: designateworker.Component,
 	}
 
@@ -714,7 +714,7 @@ func (r *DesignateWorkerReconciler) reconcileNormal(ctx context.Context, instanc
 		if networkReady {
 			instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
 		} else {
-			err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachments)
+			err := fmt.Errorf("%w: %s", designate.ErrNetworkAttachmentConfig, instance.Spec.NetworkAttachments)
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.NetworkAttachmentsReadyCondition,
 				condition.ErrorReason,
@@ -788,7 +788,7 @@ func (r *DesignateWorkerReconciler) generateServiceConfigMaps(
 	// - %-config-data configmap holding custom config for the service's designate.conf
 	//
 
-	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(instance.ObjectMeta.Name), map[string]string{})
+	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(instance.Name), map[string]string{})
 
 	db, err := mariadbv1.GetDatabaseByNameAndAccount(ctx, h, designate.DatabaseName, instance.Spec.DatabaseAccount, instance.Namespace)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openstack-k8s-operators/designate-operator
 
-go 1.21
+go 1.24
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package main implements the designate-operator controller manager.
 package main
 
 import (

--- a/pkg/designate/bind_ctrl_network.go
+++ b/pkg/designate/bind_ctrl_network.go
@@ -12,6 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package designate contains designate service functionality and configuration.
 package designate
 
 import (
@@ -28,7 +29,7 @@ func GetPredictableIPAM(networkParameters *NetworkParameters) (*NADIpam, error) 
 	endRange := predParams.RangeStart
 	for i := 0; i < BindProvPredictablePoolSize; i++ {
 		if !predParams.CIDR.Contains(endRange) {
-			return nil, fmt.Errorf("predictable IPs: cannot allocate %d IP addresses in %s", BindProvPredictablePoolSize, predParams.CIDR)
+			return nil, fmt.Errorf("%w: %d IP addresses in %s", ErrPredictableIPAllocation, BindProvPredictablePoolSize, predParams.CIDR)
 		}
 		endRange = endRange.Next()
 	}
@@ -36,6 +37,7 @@ func GetPredictableIPAM(networkParameters *NetworkParameters) (*NADIpam, error) 
 	return predParams, nil
 }
 
+// GetNextIP returns the next available IP from the given IPAM parameters
 func GetNextIP(predParams *NADIpam, allocatedIPs map[string]bool) (string, error) {
 	for candidateAddress := predParams.RangeStart; candidateAddress != predParams.RangeEnd; candidateAddress = candidateAddress.Next() {
 		if !allocatedIPs[candidateAddress.String()] {
@@ -43,5 +45,5 @@ func GetNextIP(predParams *NADIpam, allocatedIPs map[string]bool) (string, error
 			return candidateAddress.String(), nil
 		}
 	}
-	return "", fmt.Errorf("predictable IPs: out of available addresses")
+	return "", ErrPredictableIPOutOfAddresses
 }

--- a/pkg/designate/common.go
+++ b/pkg/designate/common.go
@@ -17,9 +17,23 @@ limitations under the License.
 package designate
 
 import (
+	"errors"
 	"fmt"
 
 	mariadbv1 "github.com/openstack-k8s-operators/mariadb-operator/api/v1beta1"
+)
+
+// Common static errors for all designate functionality
+var (
+	// Controller errors
+	ErrRedisRequired               = errors.New("unable to configure designate deployment without Redis")
+	ErrNetworkAttachmentConfig     = errors.New("not all pods have interfaces with ips as configured in NetworkAttachments")
+	ErrNetworkAttachmentNotFound   = errors.New("unable to locate network attachment")
+	ErrControlNetworkNotConfigured = errors.New("designate control network attachment not configured, check NetworkAttachments and ControlNetworkName")
+	// Package errors
+	ErrPredictableIPAllocation     = errors.New("predictable IPs: cannot allocate IP addresses")
+	ErrPredictableIPOutOfAddresses = errors.New("predictable IPs: out of available addresses")
+	ErrCannotAllocateIPAddresses   = errors.New("cannot allocate IP addresses")
 )
 
 const (

--- a/pkg/designate/const.go
+++ b/pkg/designate/const.go
@@ -36,26 +36,37 @@ const (
 	// DesignateInternalPort -
 	DesignateInternalPort int32 = 9001
 
+	// DesignateBindKeySecret is the name of the secret containing bind keys
 	DesignateBindKeySecret = "designate-bind-secret"
 
+	// DesignateRndcKey is the key name for RNDC configuration
 	DesignateRndcKey = "rndc-key"
 
+	// MdnsPredIPConfigMap is the name of the ConfigMap containing MDNS predictable IP mappings
 	MdnsPredIPConfigMap = "designate-mdns-ip-map"
 
+	// NsRecordsConfigMap is the name of the ConfigMap containing name server record parameters
 	NsRecordsConfigMap = "designate-ns-records-params"
 
+	// NsRecordsCRContent is the content key for name server records custom resource
 	NsRecordsCRContent = "designate-ns-records"
 
+	// BindPredIPConfigMap is the name of the ConfigMap containing bind predictable IP mappings
 	BindPredIPConfigMap = "designate-bind-ip-map"
 
+	// RndcConfDir is the directory path for RNDC configuration files
 	RndcConfDir = "/etc/designate/rndc-keys"
 
+	// PoolsYamlConfigMap is the name of the ConfigMap containing pools YAML configuration
 	PoolsYamlConfigMap = "designate-pools-yaml-config-map"
 
+	// PoolsYamlPath is the template path for pools YAML configuration
 	PoolsYamlPath = "designatepoolmanager/config/pools.yaml.tmpl"
 
+	// PoolsYamlHash is the hash key for pools YAML configuration
 	PoolsYamlHash = "pools-yaml-hash"
 
+	// PoolsYamlContent is the content key for pools YAML configuration
 	PoolsYamlContent = "pools-yaml-content"
 
 	// BindPredictableIPHash key for status hash
@@ -67,7 +78,7 @@ const (
 	// PredictableIPCommand -
 	PredictableIPCommand = "/usr/local/bin/container-scripts/setipalias.sh"
 
-	// ScriptsTemplate sprintf template for common scripts secret
+	// ScriptsF is the sprintf template for common scripts secret
 	ScriptsF = "%s-scripts"
 
 	// ConfigDataTemplate sprintf template for common config data secret

--- a/pkg/designate/func.go
+++ b/pkg/designate/func.go
@@ -1,7 +1,10 @@
 package designate
 
-import "fmt"
-import "sigs.k8s.io/controller-runtime/pkg/client"
+import (
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 // GetOwningDesignateName - Given a Designate-->API,Central,Worker,Mdns,Producer
 // object, returning the parent Designate object that created it (if any)
@@ -15,22 +18,27 @@ func GetOwningDesignateName(instance client.Object) string {
 	return ""
 }
 
+// ScriptsVolumeName returns the scripts volume name for the given service
 func ScriptsVolumeName(s string) string {
 	return fmt.Sprintf(ScriptsF, s)
 }
 
+// ConfigVolumeName returns the config volume name for the given service
 func ConfigVolumeName(s string) string {
 	return fmt.Sprintf(ConfigDataTemplate, s)
 }
 
+// DefaultsVolumeName returns the defaults volume name for the given service
 func DefaultsVolumeName(s string) string {
 	return fmt.Sprintf(DefaultOverwriteTemplate, s)
 }
 
+// MergedVolumeName returns the merged volume name for the given service
 func MergedVolumeName(s string) string {
 	return fmt.Sprintf("%s-merged", s)
 }
 
+// MergedDefaultsVolumeName returns the merged defaults volume name for the given service
 func MergedDefaultsVolumeName(s string) string {
 	return fmt.Sprintf("%s-merged-defaults", s)
 }

--- a/pkg/designate/generate_bind9_pools_yaml.go
+++ b/pkg/designate/generate_bind9_pools_yaml.go
@@ -11,6 +11,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package designate
 
 import (
@@ -29,6 +30,7 @@ import (
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 )
 
+// Pool represents a designate pool configuration
 type Pool struct {
 	Name        string                          `yaml:"name"`
 	Description string                          `yaml:"description"`
@@ -45,11 +47,13 @@ type Pool struct {
 // 	Priority int    `yaml:"priority"`
 // }
 
+// Nameserver represents a nameserver configuration
 type Nameserver struct {
 	Host string `yaml:"host"`
 	Port int    `yaml:"port"`
 }
 
+// Target represents a designate target configuration
 type Target struct {
 	Type        string   `yaml:"type"`
 	Description string   `yaml:"description"`
@@ -57,11 +61,13 @@ type Target struct {
 	Options     Options  `yaml:"options"`
 }
 
+// Master represents a designate master configuration
 type Master struct {
 	Host string `yaml:"host"`
 	Port int    `yaml:"port"`
 }
 
+// Options represents designate target options
 type Options struct {
 	Host        string `yaml:"host"`
 	Port        int    `yaml:"port"`
@@ -70,12 +76,13 @@ type Options struct {
 	RNDCKeyFile string `yaml:"rndc_key_file"`
 }
 
+// CatalogZone represents a designate catalog zone configuration
 type CatalogZone struct {
 	FQDN    string `yaml:"fqdn"`
 	Refresh int    `yaml:"refresh"`
 }
 
-// We sort all pool resources to get the correct hash every time
+// GeneratePoolsYamlDataAndHash sorts all pool resources to get the correct hash every time
 func GeneratePoolsYamlDataAndHash(BindMap, MdnsMap map[string]string, nsRecords []designatev1.DesignateNSRecord) (string, string, error) {
 	sort.Slice(nsRecords, func(i, j int) bool {
 		if nsRecords[i].Hostname != nsRecords[j].Hostname {
@@ -156,7 +163,7 @@ func GeneratePoolsYamlDataAndHash(BindMap, MdnsMap map[string]string, nsRecords 
 		return "", "", err
 	}
 	poolsYamlPath := path.Join(opTemplates, PoolsYamlPath)
-	poolsYaml, err := os.ReadFile(poolsYamlPath)
+	poolsYaml, err := os.ReadFile(poolsYamlPath) // #nosec G304
 	if err != nil {
 		return "", "", err
 	}

--- a/pkg/designate/initcontainer.go
+++ b/pkg/designate/initcontainer.go
@@ -31,6 +31,7 @@ type APIDetails struct {
 	Privileged           bool
 }
 
+// InitContainerDetails contains configuration for init containers
 type InitContainerDetails struct {
 	ContainerImage string
 	VolumeMounts   []corev1.VolumeMount
@@ -42,6 +43,7 @@ const (
 	InitContainerCommand = "/usr/local/bin/container-scripts/init.sh"
 )
 
+// SimpleInitContainer creates a simple init container with the provided details
 func SimpleInitContainer(init InitContainerDetails) corev1.Container {
 	runAsUser := int64(0)
 

--- a/pkg/designate/network_parameters.go
+++ b/pkg/designate/network_parameters.go
@@ -34,12 +34,14 @@ type NADConfig struct {
 	IPAM NADIpam `json:"ipam"`
 }
 
+// NADIpam represents network attachment definition IPAM configuration
 type NADIpam struct {
 	CIDR       netip.Prefix `json:"range"`
 	RangeStart netip.Addr   `json:"range_start"`
 	RangeEnd   netip.Addr   `json:"range_end"`
 }
 
+// GetNADConfig parses and returns the NAD configuration from a NetworkAttachmentDefinition
 func GetNADConfig(
 	nad *networkv1.NetworkAttachmentDefinition,
 ) (*NADConfig, error) {
@@ -76,7 +78,7 @@ func GetNetworkParametersFromNAD(
 	end := networkParameters.ProviderAllocationStart
 	for i := 0; i < BindProvPredictablePoolSize; i++ {
 		if !networkParameters.CIDR.Contains(end) {
-			return nil, fmt.Errorf("cannot allocate %d IP addresses in %s", BindProvPredictablePoolSize, networkParameters.CIDR)
+			return nil, fmt.Errorf("%w: %d IP addresses in %s", ErrCannotAllocateIPAddresses, BindProvPredictablePoolSize, networkParameters.CIDR)
 		}
 		end = end.Next()
 	}

--- a/pkg/designate/pool_update.go
+++ b/pkg/designate/pool_update.go
@@ -12,12 +12,17 @@ import (
 )
 
 const (
-	DesignateConfigVolume  = "designate-config"
-	DesignateConfigMount   = "/etc/designate"
+	// DesignateConfigVolume is the volume name for designate configuration
+	DesignateConfigVolume = "designate-config"
+	// DesignateConfigMount is the mount path for designate configuration
+	DesignateConfigMount = "/etc/designate"
+	// DesignateConfigKeyPath is the path to the designate configuration file
 	DesignateConfigKeyPath = "designate.conf"
+	// DesignatePoolsYamlPath is the path to the designate pools YAML file
 	DesignatePoolsYamlPath = "pools.yaml"
 )
 
+// PoolUpdateJob creates a job for updating designate pools
 func PoolUpdateJob(
 	instance *designatev1beta1.Designate,
 	labels map[string]string,

--- a/pkg/designate/predipcontainer.go
+++ b/pkg/designate/predipcontainer.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+// PredIPContainerDetails contains configuration for predictable IP containers
 type PredIPContainerDetails struct {
 	ContainerImage string
 	VolumeMounts   []corev1.VolumeMount
@@ -27,6 +28,7 @@ type PredIPContainerDetails struct {
 	EnvVars        []corev1.EnvVar
 }
 
+// PredictableIPContainer creates a container with predictable IP configuration
 func PredictableIPContainer(init PredIPContainerDetails) corev1.Container {
 
 	args := []string{

--- a/pkg/designate/rndckeygenerator.go
+++ b/pkg/designate/rndckeygenerator.go
@@ -26,6 +26,7 @@ import (
 )
 
 const (
+	// MinPasswordSize is the minimum size for generated passwords
 	MinPasswordSize = 25
 )
 
@@ -44,7 +45,7 @@ func genword(length int) (string, error) {
 	return string(password), nil
 }
 
-// Create the rndc key secret
+// CreateRndcKeySecret creates the rndc key secret
 func CreateRndcKeySecret() (string, error) {
 	// Generate random strings
 	key, err := genword(MinPasswordSize)

--- a/pkg/designate/volumes.go
+++ b/pkg/designate/volumes.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// VolumeMapping represents a volume mapping configuration for containers
 type VolumeMapping struct {
 	Name      string
 	Type      string
@@ -28,12 +29,17 @@ type VolumeMapping struct {
 }
 
 const (
+	// ScriptMount represents the script mount type
 	ScriptMount = "script-mount"
+	// SecretMount represents the secret mount type
 	SecretMount = "secret-mount"
+	// ConfigMount represents the config mount type
 	ConfigMount = "config-mount"
-	MergeMount  = "merge-mount"
+	// MergeMount represents the merge mount type
+	MergeMount = "merge-mount"
 )
 
+// GetStandardVolumeMapping returns the standard volume mappings for a designate instance
 func GetStandardVolumeMapping(instance client.Object) []VolumeMapping {
 	return []VolumeMapping{
 		{Name: ScriptsVolumeName(GetOwningDesignateName(instance)), Type: ScriptMount, MountPath: "/usr/local/bin/container-scripts"},
@@ -62,7 +68,8 @@ func ProcessVolumes(volumeDefs []VolumeMapping) ([]corev1.Volume, []corev1.Volum
 		accessMode := modeMap[v.Type]
 		var newVolume corev1.Volume
 		var newMount corev1.VolumeMount
-		if v.Type == SecretMount || v.Type == ScriptMount {
+		switch v.Type {
+		case SecretMount, ScriptMount:
 			source := v.Name
 			if len(v.Source) > 0 {
 				source = v.Source
@@ -81,7 +88,7 @@ func ProcessVolumes(volumeDefs []VolumeMapping) ([]corev1.Volume, []corev1.Volum
 				MountPath: v.MountPath,
 				ReadOnly:  true,
 			}
-		} else if v.Type == ConfigMount {
+		case ConfigMount:
 			source := v.Name
 			if len(v.Source) > 0 {
 				source = v.Source
@@ -102,7 +109,7 @@ func ProcessVolumes(volumeDefs []VolumeMapping) ([]corev1.Volume, []corev1.Volum
 				MountPath: v.MountPath,
 				ReadOnly:  true,
 			}
-		} else {
+		default:
 			newVolume = corev1.Volume{
 				Name: v.Name,
 				VolumeSource: corev1.VolumeSource{

--- a/pkg/designateapi/const.go
+++ b/pkg/designateapi/const.go
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package designateapi contains designate API constants and configuration.
 package designateapi
 
 const (

--- a/pkg/designatebackendbind9/const.go
+++ b/pkg/designatebackendbind9/const.go
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package designatebackendbind9 contains designate backend bind9 constants and configuration.
 package designatebackendbind9
 
 const (

--- a/pkg/designatebackendbind9/deployment.go
+++ b/pkg/designatebackendbind9/deployment.go
@@ -37,11 +37,11 @@ import (
 // certs etc here.
 
 const (
-	// PVCSuffix
+	// PVCSuffix is the suffix used for PVC names
 	PVCSuffix = "-designate-bind"
 )
 
-// Deployment func
+// StatefulSet creates a StatefulSet for the designate backend bind9 service
 func StatefulSet(
 	instance *designatev1beta1.DesignateBackendbind9,
 	configHash string,

--- a/pkg/designatecentral/const.go
+++ b/pkg/designatecentral/const.go
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package designatecentral contains designate central constants and configuration.
 package designatecentral
 
 const (

--- a/pkg/designatemdns/const.go
+++ b/pkg/designatemdns/const.go
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package designatemdns contains designate MDNS constants and configuration.
 package designatemdns
 
 const (

--- a/pkg/designateproducer/const.go
+++ b/pkg/designateproducer/const.go
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package designateproducer contains designate producer constants and configuration.
 package designateproducer
 
 const (

--- a/pkg/designateunbound/const.go
+++ b/pkg/designateunbound/const.go
@@ -14,9 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package designateunbound contains designate unbound constants and configuration.
 package designateunbound
 
 const (
-	Component   = "designate-unbound"
+	// Component represents the designate unbound component name
+	Component = "designate-unbound"
+	// ServiceName is the name of the designate unbound service
 	ServiceName = "designateunbound"
 )

--- a/pkg/designateworker/const.go
+++ b/pkg/designateworker/const.go
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package designateworker contains designate worker constants and configuration.
 package designateworker
 
 const (

--- a/tests/functional/api_fixture.go
+++ b/tests/functional/api_fixture.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package functional_test contains functional tests for the designate operator.
 package functional_test
 
 import (
@@ -24,7 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 
-	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck,revive // ST1001,dot-imports: dot imports are standard practice for Ginkgo tests
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
@@ -61,6 +62,7 @@ func keystoneHandleProjects(
 	}
 }
 
+// GetProject returns a project by name from the keystone projects list
 func GetProject(name string) *projects.Project {
 	for _, p := range keystoneProjects {
 		if p.Name == name {
@@ -89,14 +91,16 @@ func keystoneGetProject(
 	}
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(200)
-	fmt.Fprint(w, string(bytes))
-	f.APIFixture.Log.Info(fmt.Sprintf("GetProject returns %s", string(bytes)))
+	_, _ = fmt.Fprint(w, string(bytes))
+	f.Log.Info(fmt.Sprintf("GetProject returns %s", string(bytes)))
 }
 
+// APIFixtures contains test fixtures for API testing
 type APIFixtures struct {
 	Keystone *keystone_helpers.KeystoneAPIFixture
 }
 
+// SetupAPIFixtures sets up and returns API fixtures for testing
 func SetupAPIFixtures(logger logr.Logger) APIFixtures {
 	keystone := keystone_helpers.NewKeystoneAPIFixtureWithServer(logger)
 	keystone.Users = map[string]users.User{

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -42,12 +42,12 @@ import (
 
 const (
 	SecretName         = "test-secret"
-	KeystoneSecretName = "%s-keystone-secret"
+	KeystoneSecretName = "%s-keystone-secret" // #nosec G101
 	RabbitmqSecretName = "rabbitmq-secret"
 
-	PublicCertSecretName   = "public-tls-certs"
-	InternalCertSecretName = "internal-tls-certs"
-	CABundleSecretName     = "combined-ca-bundle"
+	PublicCertSecretName   = "public-tls-certs"   // #nosec G101
+	InternalCertSecretName = "internal-tls-certs" // #nosec G101
+	CABundleSecretName     = "combined-ca-bundle" // #nosec G101
 
 	timeout  = time.Second * 5
 	interval = timeout / 100
@@ -179,17 +179,17 @@ func GetDefaultDesignateSpec(bind9ReplicaCount, mdnsReplicaCount int, unboundRep
 	}
 	spec["designateBackendbind9"] = designatev1.DesignateBackendbind9Spec{
 		DesignateBackendbind9SpecBase: designatev1.DesignateBackendbind9SpecBase{
-			Replicas: ptr.To(int32(bind9ReplicaCount)),
+			Replicas: ptr.To(int32(bind9ReplicaCount)), // #nosec G115
 		},
 	}
 	spec["designateMdns"] = designatev1.DesignateMdnsSpec{
 		DesignateMdnsSpecBase: designatev1.DesignateMdnsSpecBase{
-			Replicas: ptr.To(int32(mdnsReplicaCount)),
+			Replicas: ptr.To(int32(mdnsReplicaCount)), // #nosec G115
 		},
 	}
 	spec["designateUnbound"] = designatev1.DesignateUnboundSpec{
 		DesignateUnboundSpecBase: designatev1.DesignateUnboundSpecBase{
-			Replicas: ptr.To(int32(unboundReplicaCount)),
+			Replicas: ptr.To(int32(unboundReplicaCount)), // #nosec G115
 		},
 	}
 	return spec

--- a/tests/functional/designate_controller_test.go
+++ b/tests/functional/designate_controller_test.go
@@ -143,9 +143,9 @@ var _ = Describe("Designate controller", func() {
 
 	BeforeEach(func() {
 		name = fmt.Sprintf("designate-%s", uuid.New().String())
-		bind9ReplicaCount = rand.Intn(5) + 1
-		mdnsReplicaCount = rand.Intn(5) + 1
-		unboundReplicaCount = rand.Intn(5) + 1
+		bind9ReplicaCount = rand.Intn(5) + 1   // #nosec G404
+		mdnsReplicaCount = rand.Intn(5) + 1    // #nosec G404
+		unboundReplicaCount = rand.Intn(5) + 1 // #nosec G404
 		spec = GetDefaultDesignateSpec(bind9ReplicaCount, mdnsReplicaCount, unboundReplicaCount)
 
 		designateName = types.NamespacedName{
@@ -598,7 +598,7 @@ var _ = Describe("Designate controller", func() {
 			bindConfigMap := th.GetConfigMap(types.NamespacedName{
 				Name:      designate.BindPredIPConfigMap,
 				Namespace: namespace})
-			Expect(len(bindConfigMap.Data)).To(Equal(bind9ReplicaCount))
+			Expect(bindConfigMap.Data).To(HaveLen(bind9ReplicaCount))
 
 			usedIPs := make(map[string]bool)
 			for key, ipAddress := range bindConfigMap.Data {
@@ -617,7 +617,7 @@ var _ = Describe("Designate controller", func() {
 			mdnsConfigMap := th.GetConfigMap(types.NamespacedName{
 				Name:      designate.MdnsPredIPConfigMap,
 				Namespace: namespace})
-			Expect(len(mdnsConfigMap.Data)).To(Equal(mdnsReplicaCount))
+			Expect(mdnsConfigMap.Data).To(HaveLen(mdnsReplicaCount))
 			for key, ipAddress := range mdnsConfigMap.Data {
 				// verify key with mdns_address_N format
 				Expect(key).To(MatchRegexp(`^mdns_address_\d+$`))

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -243,11 +243,11 @@ var _ = BeforeSuite(func() {
 	dialer := &net.Dialer{Timeout: time.Second}
 	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
 	Eventually(func() error {
-		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true}) // #nosec G402
 		if err != nil {
 			return err
 		}
-		conn.Close()
+		_ = conn.Close()
 		return nil
 	}).Should(Succeed())
 })


### PR DESCRIPTION
* bump in go.mod (base and api)
* bump go-toolset in Dockerfile
* bump golang version and custom_image in github jobs ('.github/workflows')
* Bump the golangci-lint version in the .pre-commit-config.yaml to v2.4.0
* Bump build_root_image in .ci-operator.yaml to ci-build-root-golang-1.24-sdk-1.31 (if set)

To test on existing env:
* update golang to 1.24
* delete current `go.work*` files
* init go work files `go work init`

Depends-On: https://github.com/openstack-k8s-operators/install_yamls/pull/1082
Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1567

Jira: [OSPRH-12935](https://issues.redhat.com//browse/OSPRH-12935)