### PR TITLE
fix: update broken Kubernetes documentation links in CRDs

### DIFF
--- a/api/bases/designate.openstack.org_designateapis.yaml
+++ b/api/bases/designate.openstack.org_designateapis.yaml
@@ -144,7 +144,7 @@ spec:
                                 Annotations is an unstructured key value map stored with a resource that may be
                                 set by external tools to store and retrieve arbitrary metadata. They are not
                                 queryable and should be preserved when modifying objects.
-                                More info: http://kubernetes.io/docs/user-guide/annotations
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                               type: object
                             labels:
                               additionalProperties:
@@ -153,7 +153,7 @@ spec:
                                 Map of string keys and values that can be used to organize and categorize
                                 (scope and select) objects. May match selectors of replication controllers
                                 and services.
-                                More info: http://kubernetes.io/docs/user-guide/labels
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                               type: object
                           type: object
                         spec:

--- a/api/bases/designate.openstack.org_designatebackendbind9s.yaml
+++ b/api/bases/designate.openstack.org_designatebackendbind9s.yaml
@@ -148,7 +148,7 @@ spec:
                                 Annotations is an unstructured key value map stored with a resource that may be
                                 set by external tools to store and retrieve arbitrary metadata. They are not
                                 queryable and should be preserved when modifying objects.
-                                More info: http://kubernetes.io/docs/user-guide/annotations
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                               type: object
                             labels:
                               additionalProperties:
@@ -157,7 +157,7 @@ spec:
                                 Map of string keys and values that can be used to organize and categorize
                                 (scope and select) objects. May match selectors of replication controllers
                                 and services.
-                                More info: http://kubernetes.io/docs/user-guide/labels
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                               type: object
                           type: object
                         spec:

--- a/api/bases/designate.openstack.org_designatemdnses.yaml
+++ b/api/bases/designate.openstack.org_designatemdnses.yaml
@@ -148,7 +148,7 @@ spec:
                                 Annotations is an unstructured key value map stored with a resource that may be
                                 set by external tools to store and retrieve arbitrary metadata. They are not
                                 queryable and should be preserved when modifying objects.
-                                More info: http://kubernetes.io/docs/user-guide/annotations
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                               type: object
                             labels:
                               additionalProperties:
@@ -157,7 +157,7 @@ spec:
                                 Map of string keys and values that can be used to organize and categorize
                                 (scope and select) objects. May match selectors of replication controllers
                                 and services.
-                                More info: http://kubernetes.io/docs/user-guide/labels
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                               type: object
                           type: object
                         spec:

--- a/api/bases/designate.openstack.org_designates.yaml
+++ b/api/bases/designate.openstack.org_designates.yaml
@@ -191,7 +191,7 @@ spec:
                                     Annotations is an unstructured key value map stored with a resource that may be
                                     set by external tools to store and retrieve arbitrary metadata. They are not
                                     queryable and should be preserved when modifying objects.
-                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                                   type: object
                                 labels:
                                   additionalProperties:
@@ -200,7 +200,7 @@ spec:
                                     Map of string keys and values that can be used to organize and categorize
                                     (scope and select) objects. May match selectors of replication controllers
                                     and services.
-                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                                   type: object
                               type: object
                             spec:
@@ -573,7 +573,7 @@ spec:
                                     Annotations is an unstructured key value map stored with a resource that may be
                                     set by external tools to store and retrieve arbitrary metadata. They are not
                                     queryable and should be preserved when modifying objects.
-                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                                   type: object
                                 labels:
                                   additionalProperties:
@@ -582,7 +582,7 @@ spec:
                                     Map of string keys and values that can be used to organize and categorize
                                     (scope and select) objects. May match selectors of replication controllers
                                     and services.
-                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                                   type: object
                               type: object
                             spec:
@@ -1119,7 +1119,7 @@ spec:
                                     Annotations is an unstructured key value map stored with a resource that may be
                                     set by external tools to store and retrieve arbitrary metadata. They are not
                                     queryable and should be preserved when modifying objects.
-                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                                   type: object
                                 labels:
                                   additionalProperties:
@@ -1128,7 +1128,7 @@ spec:
                                     Map of string keys and values that can be used to organize and categorize
                                     (scope and select) objects. May match selectors of replication controllers
                                     and services.
-                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                                   type: object
                               type: object
                             spec:
@@ -1639,7 +1639,7 @@ spec:
                                     Annotations is an unstructured key value map stored with a resource that may be
                                     set by external tools to store and retrieve arbitrary metadata. They are not
                                     queryable and should be preserved when modifying objects.
-                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                                   type: object
                                 labels:
                                   additionalProperties:
@@ -1648,7 +1648,7 @@ spec:
                                     Map of string keys and values that can be used to organize and categorize
                                     (scope and select) objects. May match selectors of replication controllers
                                     and services.
-                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                                   type: object
                               type: object
                             spec:

--- a/api/bases/designate.openstack.org_designateunbounds.yaml
+++ b/api/bases/designate.openstack.org_designateunbounds.yaml
@@ -110,7 +110,7 @@ spec:
                                 Annotations is an unstructured key value map stored with a resource that may be
                                 set by external tools to store and retrieve arbitrary metadata. They are not
                                 queryable and should be preserved when modifying objects.
-                                More info: http://kubernetes.io/docs/user-guide/annotations
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                               type: object
                             labels:
                               additionalProperties:
@@ -119,7 +119,7 @@ spec:
                                 Map of string keys and values that can be used to organize and categorize
                                 (scope and select) objects. May match selectors of replication controllers
                                 and services.
-                                More info: http://kubernetes.io/docs/user-guide/labels
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                               type: object
                           type: object
                         spec:

--- a/config/crd/bases/designate.openstack.org_designateapis.yaml
+++ b/config/crd/bases/designate.openstack.org_designateapis.yaml
@@ -144,7 +144,7 @@ spec:
                                 Annotations is an unstructured key value map stored with a resource that may be
                                 set by external tools to store and retrieve arbitrary metadata. They are not
                                 queryable and should be preserved when modifying objects.
-                                More info: http://kubernetes.io/docs/user-guide/annotations
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                               type: object
                             labels:
                               additionalProperties:
@@ -153,7 +153,7 @@ spec:
                                 Map of string keys and values that can be used to organize and categorize
                                 (scope and select) objects. May match selectors of replication controllers
                                 and services.
-                                More info: http://kubernetes.io/docs/user-guide/labels
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                               type: object
                           type: object
                         spec:

--- a/config/crd/bases/designate.openstack.org_designatebackendbind9s.yaml
+++ b/config/crd/bases/designate.openstack.org_designatebackendbind9s.yaml
@@ -148,7 +148,7 @@ spec:
                                 Annotations is an unstructured key value map stored with a resource that may be
                                 set by external tools to store and retrieve arbitrary metadata. They are not
                                 queryable and should be preserved when modifying objects.
-                                More info: http://kubernetes.io/docs/user-guide/annotations
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                               type: object
                             labels:
                               additionalProperties:
@@ -157,7 +157,7 @@ spec:
                                 Map of string keys and values that can be used to organize and categorize
                                 (scope and select) objects. May match selectors of replication controllers
                                 and services.
-                                More info: http://kubernetes.io/docs/user-guide/labels
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                               type: object
                           type: object
                         spec:

--- a/config/crd/bases/designate.openstack.org_designatemdnses.yaml
+++ b/config/crd/bases/designate.openstack.org_designatemdnses.yaml
@@ -148,7 +148,7 @@ spec:
                                 Annotations is an unstructured key value map stored with a resource that may be
                                 set by external tools to store and retrieve arbitrary metadata. They are not
                                 queryable and should be preserved when modifying objects.
-                                More info: http://kubernetes.io/docs/user-guide/annotations
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                               type: object
                             labels:
                               additionalProperties:
@@ -157,7 +157,7 @@ spec:
                                 Map of string keys and values that can be used to organize and categorize
                                 (scope and select) objects. May match selectors of replication controllers
                                 and services.
-                                More info: http://kubernetes.io/docs/user-guide/labels
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                               type: object
                           type: object
                         spec:

--- a/config/crd/bases/designate.openstack.org_designates.yaml
+++ b/config/crd/bases/designate.openstack.org_designates.yaml
@@ -191,7 +191,7 @@ spec:
                                     Annotations is an unstructured key value map stored with a resource that may be
                                     set by external tools to store and retrieve arbitrary metadata. They are not
                                     queryable and should be preserved when modifying objects.
-                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                                   type: object
                                 labels:
                                   additionalProperties:
@@ -200,7 +200,7 @@ spec:
                                     Map of string keys and values that can be used to organize and categorize
                                     (scope and select) objects. May match selectors of replication controllers
                                     and services.
-                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                                   type: object
                               type: object
                             spec:
@@ -573,7 +573,7 @@ spec:
                                     Annotations is an unstructured key value map stored with a resource that may be
                                     set by external tools to store and retrieve arbitrary metadata. They are not
                                     queryable and should be preserved when modifying objects.
-                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                                   type: object
                                 labels:
                                   additionalProperties:
@@ -582,7 +582,7 @@ spec:
                                     Map of string keys and values that can be used to organize and categorize
                                     (scope and select) objects. May match selectors of replication controllers
                                     and services.
-                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                                   type: object
                               type: object
                             spec:
@@ -1119,7 +1119,7 @@ spec:
                                     Annotations is an unstructured key value map stored with a resource that may be
                                     set by external tools to store and retrieve arbitrary metadata. They are not
                                     queryable and should be preserved when modifying objects.
-                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                                   type: object
                                 labels:
                                   additionalProperties:
@@ -1128,7 +1128,7 @@ spec:
                                     Map of string keys and values that can be used to organize and categorize
                                     (scope and select) objects. May match selectors of replication controllers
                                     and services.
-                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                                   type: object
                               type: object
                             spec:
@@ -1639,7 +1639,7 @@ spec:
                                     Annotations is an unstructured key value map stored with a resource that may be
                                     set by external tools to store and retrieve arbitrary metadata. They are not
                                     queryable and should be preserved when modifying objects.
-                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                                   type: object
                                 labels:
                                   additionalProperties:
@@ -1648,7 +1648,7 @@ spec:
                                     Map of string keys and values that can be used to organize and categorize
                                     (scope and select) objects. May match selectors of replication controllers
                                     and services.
-                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                                   type: object
                               type: object
                             spec:

--- a/config/crd/bases/designate.openstack.org_designateunbounds.yaml
+++ b/config/crd/bases/designate.openstack.org_designateunbounds.yaml
@@ -110,7 +110,7 @@ spec:
                                 Annotations is an unstructured key value map stored with a resource that may be
                                 set by external tools to store and retrieve arbitrary metadata. They are not
                                 queryable and should be preserved when modifying objects.
-                                More info: http://kubernetes.io/docs/user-guide/annotations
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
                               type: object
                             labels:
                               additionalProperties:
@@ -119,7 +119,7 @@ spec:
                                 Map of string keys and values that can be used to organize and categorize
                                 (scope and select) objects. May match selectors of replication controllers
                                 and services.
-                                More info: http://kubernetes.io/docs/user-guide/labels
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
                               type: object
                           type: object
                         spec:


### PR DESCRIPTION
Update HTTP URLs to HTTPS and fix deprecated documentation paths for annotations and labels references in all CRD schema definitions.

Assisted-by: claude-4-sonnet