### PR TITLE
Modernize Go code with latest style conventions

### DIFF
--- a/controllers/designate_common.go
+++ b/controllers/designate_common.go
@@ -26,7 +26,7 @@ import (
 
 type conditionUpdater interface {
 	Set(c *condition.Condition)
-	MarkTrue(t condition.Type, messageFormat string, messageArgs ...interface{})
+	MarkTrue(t condition.Type, messageFormat string, messageArgs ...any)
 }
 
 type topologyHandler interface {

--- a/controllers/designateapi_controller.go
+++ b/controllers/designateapi_controller.go
@@ -1148,16 +1148,16 @@ func (r *DesignateAPIReconciler) generateServiceConfigMaps(
 
 	customData[common.CustomServiceConfigFileName] = instance.Spec.CustomServiceConfig
 
-	templateParameters := map[string]interface{}{
+	templateParameters := map[string]any{
 		"KeystoneInternalURL": keystoneInternalURL,
 		"KeystonePublicURL":   keystonePublicURL,
 		"TimeOut":             instance.Spec.APITimeout,
 	}
 
 	// create httpd  vhost template parameters
-	httpdVhostConfig := map[string]interface{}{}
+	httpdVhostConfig := map[string]any{}
 	for _, endpt := range []service.Endpoint{service.EndpointInternal, service.EndpointPublic} {
-		endptConfig := map[string]interface{}{}
+		endptConfig := map[string]any{}
 		endptConfig["ServerName"] = fmt.Sprintf("%s-%s.%s.svc", designate.ServiceName, endpt.String(), instance.Namespace)
 		endptConfig["TLS"] = false // default TLS to false, and set it bellow to true if enabled
 		if instance.Spec.TLS.API.Enabled(endpt) {

--- a/controllers/designatebackendbind9_controller.go
+++ b/controllers/designatebackendbind9_controller.go
@@ -405,7 +405,7 @@ func (r *DesignateBackendbind9Reconciler) reconcileNormal(ctx context.Context, i
 	// TODO(beagles): we really should create a single point of truth for what things are named or
 	// what the names will be based on.
 	serviceCount := min(int(*instance.Spec.Replicas), len(instance.Spec.Override.Services))
-	for i := 0; i < serviceCount; i++ {
+	for i := range serviceCount {
 		svc, err := designate.CreateDNSService(
 			fmt.Sprintf("designate-backendbind9-%d", i),
 			instance.Namespace,
@@ -765,7 +765,7 @@ func (r *DesignateBackendbind9Reconciler) generateServiceConfigMaps(
 			err))
 		return err
 	}
-	templateParameters := make(map[string]interface{})
+	templateParameters := make(map[string]any)
 	if nadInfo.IPAM.CIDR.Addr().Is4() {
 		templateParameters["IPVersion"] = "4"
 	} else {

--- a/controllers/designatecentral_controller.go
+++ b/controllers/designatecentral_controller.go
@@ -666,7 +666,7 @@ func (r *DesignateCentralReconciler) generateServiceConfigMaps(
 		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(oschwart) for now just get the default my.cnf
 	}
 
-	templateParameters := map[string]interface{}{}
+	templateParameters := map[string]any{}
 	cms := []util.Template{
 		// Custom ConfigMap
 		{

--- a/controllers/designatemdns_controller.go
+++ b/controllers/designatemdns_controller.go
@@ -532,7 +532,7 @@ func (r *DesignateMdnsReconciler) reconcileNormal(ctx context.Context, instance 
 	}
 
 	serviceCount := min(int(*instance.Spec.Replicas), len(instance.Spec.Override.Services))
-	for i := 0; i < serviceCount; i++ {
+	for i := range serviceCount {
 		svc, err := designate.CreateDNSService(
 			fmt.Sprintf("designate-mdns-%d", i),
 			instance.Namespace,
@@ -850,7 +850,7 @@ func (r *DesignateMdnsReconciler) generateServiceConfigMaps(
 			Type:          util.TemplateTypeConfig,
 			InstanceType:  instance.Kind,
 			CustomData:    customData,
-			ConfigOptions: make(map[string]interface{}),
+			ConfigOptions: make(map[string]any),
 			Labels:        cmLabels,
 		},
 		{

--- a/controllers/designateproducer_controller.go
+++ b/controllers/designateproducer_controller.go
@@ -804,7 +804,7 @@ func (r *DesignateProducerReconciler) generateServiceConfigMaps(
 		"my.cnf":                           db.GetDatabaseClientConfig(tlsCfg), //(oschwart) for now just get the default my.cnf
 	}
 
-	templateParameters := map[string]interface{}{}
+	templateParameters := map[string]any{}
 
 	cms := []util.Template{
 		// Custom ConfigMap

--- a/controllers/designateworker_controller.go
+++ b/controllers/designateworker_controller.go
@@ -814,7 +814,7 @@ func (r *DesignateWorkerReconciler) generateServiceConfigMaps(
 			Type:          util.TemplateTypeConfig,
 			InstanceType:  instance.Kind,
 			CustomData:    customData,
-			ConfigOptions: make(map[string]interface{}),
+			ConfigOptions: make(map[string]any),
 			Labels:        cmLabels,
 		},
 		{

--- a/pkg/designate/bind_ctrl_network.go
+++ b/pkg/designate/bind_ctrl_network.go
@@ -27,7 +27,7 @@ func GetPredictableIPAM(networkParameters *NetworkParameters) (*NADIpam, error) 
 	predParams.CIDR = networkParameters.CIDR
 	predParams.RangeStart = networkParameters.ProviderAllocationEnd.Next()
 	endRange := predParams.RangeStart
-	for i := 0; i < BindProvPredictablePoolSize; i++ {
+	for range BindProvPredictablePoolSize {
 		if !predParams.CIDR.Contains(endRange) {
 			return nil, fmt.Errorf("%w: %d IP addresses in %s", ErrPredictableIPAllocation, BindProvPredictablePoolSize, predParams.CIDR)
 		}

--- a/pkg/designate/generate_bind9_pools_yaml.go
+++ b/pkg/designate/generate_bind9_pools_yaml.go
@@ -105,7 +105,7 @@ func GeneratePoolsYamlDataAndHash(BindMap, MdnsMap map[string]string, nsRecords 
 
 	targets := make([]Target, len(bindIPs))
 	nameservers := make([]Nameserver, len(bindIPs))
-	for i := 0; i < len(bindIPs); i++ {
+	for i := range bindIPs {
 		masters := make([]Master, len(masterHosts))
 		for j, masterHost := range masterHosts {
 			masters[j] = Master{

--- a/pkg/designate/network_parameters.go
+++ b/pkg/designate/network_parameters.go
@@ -76,7 +76,7 @@ func GetNetworkParametersFromNAD(
 	// RangeEnd.
 	networkParameters.ProviderAllocationStart = nadConfig.IPAM.RangeEnd.Next()
 	end := networkParameters.ProviderAllocationStart
-	for i := 0; i < BindProvPredictablePoolSize; i++ {
+	for range BindProvPredictablePoolSize {
 		if !networkParameters.CIDR.Contains(end) {
 			return nil, fmt.Errorf("%w: %d IP addresses in %s", ErrCannotAllocateIPAddresses, BindProvPredictablePoolSize, networkParameters.CIDR)
 		}

--- a/pkg/designate/volumes.go
+++ b/pkg/designate/volumes.go
@@ -63,7 +63,7 @@ func ProcessVolumes(volumeDefs []VolumeMapping) ([]corev1.Volume, []corev1.Volum
 		ConfigMount: 0640,
 		MergeMount:  0,
 	}
-	for i := 0; i < len(volumeDefs); i++ {
+	for i := range volumeDefs {
 		v := &volumeDefs[i]
 		accessMode := modeMap[v.Type]
 		var newVolume corev1.Volume

--- a/tests/functional/base_test.go
+++ b/tests/functional/base_test.go
@@ -71,7 +71,7 @@ func CreateTransportURLSecret(name types.NamespacedName) *corev1.Secret {
 	secret := th.CreateSecret(
 		name,
 		map[string][]byte{
-			"transport_url": []byte(fmt.Sprintf("rabbit://%s/", name)),
+			"transport_url": fmt.Appendf(nil, "rabbit://%s/", name),
 		},
 	)
 	logger.Info("Created TransportURLSecret", "secret", secret)
@@ -170,8 +170,8 @@ func SimulateKeystoneReady(
 	}, timeout, interval).Should(Succeed())
 }
 
-func GetDefaultDesignateSpec(bind9ReplicaCount, mdnsReplicaCount int, unboundReplicaCount int) map[string]interface{} {
-	spec := map[string]interface{}{
+func GetDefaultDesignateSpec(bind9ReplicaCount, mdnsReplicaCount int, unboundReplicaCount int) map[string]any {
+	spec := map[string]any{
 		"databaseInstance":           "test-designate-db-instance",
 		"secret":                     SecretName,
 		"designateNetworkAttachment": "designate-attachement",
@@ -195,12 +195,12 @@ func GetDefaultDesignateSpec(bind9ReplicaCount, mdnsReplicaCount int, unboundRep
 	return spec
 }
 
-func CreateDesignate(name types.NamespacedName, spec map[string]interface{}) client.Object {
+func CreateDesignate(name types.NamespacedName, spec map[string]any) client.Object {
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "designate.openstack.org/v1beta1",
 		"kind":       "Designate",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
@@ -234,8 +234,8 @@ func CreateDesignateSecret(namespace string) *corev1.Secret {
 }
 
 // DesignateAPI
-func GetDefaultDesignateAPISpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultDesignateAPISpec() map[string]any {
+	return map[string]any{
 		"databaseHostname":           "hostname-for-designate-api",
 		"databaseInstance":           "test-designate-db-instance",
 		"secret":                     SecretName,
@@ -245,8 +245,8 @@ func GetDefaultDesignateAPISpec() map[string]interface{} {
 	}
 }
 
-func CreateDesignateAPI(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	ownerReferences := []map[string]interface{}{{
+func CreateDesignateAPI(name types.NamespacedName, spec map[string]any) client.Object {
+	ownerReferences := []map[string]any{{
 		"apiVersion":         "designate.openstack.org/v1beta1",
 		"blockOwnerDeletion": true,
 		"controller":         true,
@@ -254,10 +254,10 @@ func CreateDesignateAPI(name types.NamespacedName, spec map[string]interface{}) 
 		"name":               "designate",
 		"uid":                uuid.New().String(),
 	}}
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "designate.openstack.org/v1beta1",
 		"kind":       "DesignateAPI",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":            name.Name,
 			"namespace":       name.Namespace,
 			"ownerReferences": ownerReferences,
@@ -314,8 +314,8 @@ func SimulateDesignateAPIReady(name types.NamespacedName) {
 }
 
 // DesignateBackendbind9
-func GetDefaultDesignateBackendbind9Spec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultDesignateBackendbind9Spec() map[string]any {
+	return map[string]any{
 		"databaseHostname":           "hostname-for-designate-backendbind9",
 		"secret":                     SecretName,
 		"designateNetworkAttachment": "designate-attachement",
@@ -324,8 +324,8 @@ func GetDefaultDesignateBackendbind9Spec() map[string]interface{} {
 	}
 }
 
-func CreateDesignateBackendbind9(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	ownerReferences := []map[string]interface{}{{
+func CreateDesignateBackendbind9(name types.NamespacedName, spec map[string]any) client.Object {
+	ownerReferences := []map[string]any{{
 		"apiVersion":         "designate.openstack.org/v1beta1",
 		"blockOwnerDeletion": true,
 		"controller":         true,
@@ -333,10 +333,10 @@ func CreateDesignateBackendbind9(name types.NamespacedName, spec map[string]inte
 		"name":               "designate",
 		"uid":                uuid.New().String(),
 	}}
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "designate.openstack.org/v1beta1",
 		"kind":       "DesignateBackendbind9",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":            name.Name,
 			"namespace":       name.Namespace,
 			"ownerReferences": ownerReferences,
@@ -360,8 +360,8 @@ func DesignateBackendbind9ConditionGetter(name types.NamespacedName) condition.C
 }
 
 // DesignateMdns
-func GetDefaultDesignateMdnsSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultDesignateMdnsSpec() map[string]any {
+	return map[string]any{
 		"databaseHostname":           "hostname-for-designate-mdns",
 		"databaseInstance":           "test-designate-db-instance",
 		"secret":                     SecretName,
@@ -371,8 +371,8 @@ func GetDefaultDesignateMdnsSpec() map[string]interface{} {
 	}
 }
 
-func CreateDesignateMdns(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	ownerReferences := []map[string]interface{}{{
+func CreateDesignateMdns(name types.NamespacedName, spec map[string]any) client.Object {
+	ownerReferences := []map[string]any{{
 		"apiVersion":         "designate.openstack.org/v1beta1",
 		"blockOwnerDeletion": true,
 		"controller":         true,
@@ -380,10 +380,10 @@ func CreateDesignateMdns(name types.NamespacedName, spec map[string]interface{})
 		"name":               "designate",
 		"uid":                uuid.New().String(),
 	}}
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "designate.openstack.org/v1beta1",
 		"kind":       "DesignateMdns",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":            name.Name,
 			"namespace":       name.Namespace,
 			"ownerReferences": ownerReferences,
@@ -407,8 +407,8 @@ func DesignateMdnsConditionGetter(name types.NamespacedName) condition.Condition
 }
 
 // DesignateCentral
-func GetDefaultDesignateCentralSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultDesignateCentralSpec() map[string]any {
+	return map[string]any{
 		"databaseHostname":           "hostname-for-designate-central",
 		"secret":                     SecretName,
 		"designateNetworkAttachment": "designate-attachement",
@@ -418,8 +418,8 @@ func GetDefaultDesignateCentralSpec() map[string]interface{} {
 	}
 }
 
-func CreateDesignateCentral(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	ownerReferences := []map[string]interface{}{{
+func CreateDesignateCentral(name types.NamespacedName, spec map[string]any) client.Object {
+	ownerReferences := []map[string]any{{
 		"apiVersion":         "designate.openstack.org/v1beta1",
 		"blockOwnerDeletion": true,
 		"controller":         true,
@@ -428,10 +428,10 @@ func CreateDesignateCentral(name types.NamespacedName, spec map[string]interface
 		"uid":                uuid.New().String(),
 	}}
 
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "designate.openstack.org/v1beta1",
 		"kind":       "DesignateCentral",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":            name.Name,
 			"namespace":       name.Namespace,
 			"ownerReferences": ownerReferences,
@@ -463,8 +463,8 @@ func DesignateCentralConditionGetter(name types.NamespacedName) condition.Condit
 }
 
 // DesignateProducer)
-func GetDefaultDesignateProducerSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultDesignateProducerSpec() map[string]any {
+	return map[string]any{
 		"databaseHostname":           "hostname-for-designate-producer",
 		"secret":                     SecretName,
 		"designateNetworkAttachment": "designate-attachement",
@@ -474,8 +474,8 @@ func GetDefaultDesignateProducerSpec() map[string]interface{} {
 	}
 }
 
-func CreateDesignateProducer(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	ownerReferences := []map[string]interface{}{{
+func CreateDesignateProducer(name types.NamespacedName, spec map[string]any) client.Object {
+	ownerReferences := []map[string]any{{
 		"apiVersion":         "designate.openstack.org/v1beta1",
 		"blockOwnerDeletion": true,
 		"controller":         true,
@@ -483,10 +483,10 @@ func CreateDesignateProducer(name types.NamespacedName, spec map[string]interfac
 		"name":               "designate",
 		"uid":                uuid.New().String(),
 	}}
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "designate.openstack.org/v1beta1",
 		"kind":       "DesignateProducer",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":            name.Name,
 			"namespace":       name.Namespace,
 			"ownerReferences": ownerReferences,
@@ -510,8 +510,8 @@ func DesignateProducerConditionGetter(name types.NamespacedName) condition.Condi
 }
 
 // DesignateUnbound
-func GetDefaultUnboundSpec() map[string]interface{} {
-	return map[string]interface{}{
+func GetDefaultUnboundSpec() map[string]any {
+	return map[string]any{
 		"databaseHostame":            "hostname-for-designate-unbound",
 		"secret":                     SecretName,
 		"designateNetworkAttachment": "designate-attachment",
@@ -520,8 +520,8 @@ func GetDefaultUnboundSpec() map[string]interface{} {
 	}
 }
 
-func CreateDesignateUnbound(name types.NamespacedName, spec map[string]interface{}) client.Object {
-	ownerReferences := []map[string]interface{}{{
+func CreateDesignateUnbound(name types.NamespacedName, spec map[string]any) client.Object {
+	ownerReferences := []map[string]any{{
 		"apiVersion":         "designate.openstack.org/v1beta1",
 		"blockOwnerDeletion": true,
 		"controller":         true,
@@ -529,10 +529,10 @@ func CreateDesignateUnbound(name types.NamespacedName, spec map[string]interface
 		"name":               "designate",
 		"uid":                uuid.New().String(),
 	}}
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "designate.openstack.org/v1beta1",
 		"kind":       "DesignateUnbound",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":            name.Name,
 			"namespace":       name.Namespace,
 			"ownerReferences": ownerReferences,
@@ -550,11 +550,11 @@ func GetDesignateUnbound(name types.NamespacedName) *designatev1.DesignateUnboun
 	return instance
 }
 
-func CreateBindIPMap(namespace string, configData map[string]interface{}) client.Object {
-	raw := map[string]interface{}{
+func CreateBindIPMap(namespace string, configData map[string]any) client.Object {
+	raw := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "ConfigMap",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      designate.BindPredIPConfigMap,
 			"namespace": namespace,
 		},
@@ -565,14 +565,14 @@ func CreateBindIPMap(namespace string, configData map[string]interface{}) client
 
 // Network attachment
 func CreateNAD(name types.NamespacedName) client.Object {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "k8s.cni.cncf.io/v1",
 		"kind":       "NetworkAttachmentDefinition",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
-		"spec": map[string]interface{}{
+		"spec": map[string]any{
 			"config": `{
 				"cniVersion": "0.3.1",
 				"name": "designate",
@@ -606,14 +606,14 @@ func GetNADConfig(name types.NamespacedName) *designate.NADConfig {
 }
 
 func CreateNode(name types.NamespacedName) client.Object {
-	raw := map[string]interface{}{
+	raw := map[string]any{
 		"apiVersion": "v1",
 		"kind":       "Node",
-		"metadata": map[string]interface{}{
+		"metadata": map[string]any{
 			"name":      name.Name,
 			"namespace": name.Namespace,
 		},
-		"spec": map[string]interface{}{},
+		"spec": map[string]any{},
 	}
 	return th.CreateUnstructured(raw)
 }
@@ -637,16 +637,16 @@ func CreateDesignateNSRecordsConfigMap(name types.NamespacedName) client.Object 
 // test Service components. It returns both the user input representation
 // in the form of map[string]string, and the Golang expected representation
 // used in the test asserts.
-func GetSampleTopologySpec(label string) (map[string]interface{}, []corev1.TopologySpreadConstraint) {
+func GetSampleTopologySpec(label string) (map[string]any, []corev1.TopologySpreadConstraint) {
 	// Build the topology Spec
-	topologySpec := map[string]interface{}{
-		"topologySpreadConstraints": []map[string]interface{}{
+	topologySpec := map[string]any{
+		"topologySpreadConstraints": []map[string]any{
 			{
 				"maxSkew":           1,
 				"topologyKey":       corev1.LabelHostname,
 				"whenUnsatisfiable": "ScheduleAnyway",
-				"labelSelector": map[string]interface{}{
-					"matchLabels": map[string]interface{}{
+				"labelSelector": map[string]any{
+					"matchLabels": map[string]any{
 						"component": label,
 					},
 				},

--- a/tests/functional/designate_controller_test.go
+++ b/tests/functional/designate_controller_test.go
@@ -92,7 +92,7 @@ func simulateCentralReadyCount(designateName types.NamespacedName, readyCount in
 	}, th.Timeout, th.Interval).Should(Succeed())
 }
 
-func createAndSimulateDB(spec map[string]interface{}) {
+func createAndSimulateDB(spec map[string]any) {
 	DeferCleanup(
 		mariadb.DeleteDBService,
 		mariadb.CreateDBService(
@@ -124,7 +124,7 @@ func createAndSimulateMdns(mdnsName types.NamespacedName) {
 
 var _ = Describe("Designate controller", func() {
 	var name string
-	var spec map[string]interface{}
+	var spec map[string]any
 	var designateName types.NamespacedName
 	var designateAPIName types.NamespacedName
 	var designateCentralName types.NamespacedName
@@ -464,7 +464,7 @@ var _ = Describe("Designate controller", func() {
 	// API Deployment
 	When("Designate is created with nodeSelector", func() {
 		BeforeEach(func() {
-			spec["nodeSelector"] = map[string]interface{}{
+			spec["nodeSelector"] = map[string]any{
 				"foo": "bar",
 			}
 			createAndSimulateKeystone(designateName)
@@ -775,7 +775,7 @@ var _ = Describe("Designate controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// we used to have inconsistent ordering, so generate the pools.yaml 10 times and make sure it is has exactly the same content
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				_, newPoolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, allNSRecords)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(poolsYamlHash).Should(Equal(newPoolsYamlHash))
@@ -802,7 +802,7 @@ var _ = Describe("Designate controller", func() {
 				Name:      designateTopologies[1].Name,
 				Namespace: designateTopologies[1].Namespace,
 			}
-			spec["topologyRef"] = map[string]interface{}{
+			spec["topologyRef"] = map[string]any{
 				"name": topologyRef.Name,
 			}
 			createAndSimulateKeystone(designateName)
@@ -1096,22 +1096,22 @@ var _ = Describe("Designate webhook validation", func() {
 			spec := GetDefaultDesignateSpec(1, 1, 1)
 			// Reference topology
 			if component != "top-level" {
-				spec[component] = map[string]interface{}{
-					"topologyRef": map[string]interface{}{
+				spec[component] = map[string]any{
+					"topologyRef": map[string]any{
 						"name":      "bar",
 						"namespace": "foo",
 					},
 				}
 			} else {
-				spec["topologyRef"] = map[string]interface{}{
+				spec["topologyRef"] = map[string]any{
 					"name":      "bar",
 					"namespace": "foo",
 				}
 			}
-			raw := map[string]interface{}{
+			raw := map[string]any{
 				"apiVersion": "designate.openstack.org/v1beta1",
 				"kind":       "Designate",
-				"metadata": map[string]interface{}{
+				"metadata": map[string]any{
 					"name":      designateName.Name,
 					"namespace": designateName.Namespace,
 				},

--- a/tests/functional/designateapi_controller_test.go
+++ b/tests/functional/designateapi_controller_test.go
@@ -36,7 +36,7 @@ import (
 
 var _ = Describe("DesignateAPI controller", func() {
 	var name string
-	var spec map[string]interface{}
+	var spec map[string]any
 	var designateAPIName types.NamespacedName
 	var transportURLSecretName types.NamespacedName
 

--- a/tests/functional/designatebackendbind9_controller_test.go
+++ b/tests/functional/designatebackendbind9_controller_test.go
@@ -33,7 +33,7 @@ import (
 
 var _ = Describe("DesignateBackendbind9 controller", func() {
 	var name string
-	var spec map[string]interface{}
+	var spec map[string]any
 	var designateBackendbind9Name types.NamespacedName
 	var transportURLSecretName types.NamespacedName
 

--- a/tests/functional/designatecentral_controller_test.go
+++ b/tests/functional/designatecentral_controller_test.go
@@ -34,7 +34,7 @@ import (
 
 var _ = Describe("DesignateCentral controller", func() {
 	var name string
-	var spec map[string]interface{}
+	var spec map[string]any
 	var designateCentralName types.NamespacedName
 	var designateRedisName types.NamespacedName
 	var transportURLSecretName types.NamespacedName

--- a/tests/functional/designateproducer_controller_test.go
+++ b/tests/functional/designateproducer_controller_test.go
@@ -34,7 +34,7 @@ import (
 
 var _ = Describe("DesignateProducer controller", func() {
 	var name string
-	var spec map[string]interface{}
+	var spec map[string]any
 	var designateProducerName types.NamespacedName
 	var designateRedisName types.NamespacedName
 	var transportURLSecretName types.NamespacedName


### PR DESCRIPTION
Modernize using `gopls modernize tool` to update:

- Replace interface{} with any type alias (Go 1.18+)
- Update range loops to use idiomatic range syntax
- Replace fmt.Sprintf with fmt.Appendf where appropriate

These changes improve code readability and align with current Go best practices.

Co-Authored-By: Claude <noreply@anthropic.com>