### PR TITLE
stub-prime defaults to no if unset

### DIFF
--- a/controllers/designateunbound_controller.go
+++ b/controllers/designateunbound_controller.go
@@ -541,7 +541,7 @@ func stubZoneDefaults(values map[string]string) map[string]string {
 		values = make(map[string]string)
 	}
 	if _, ok := values["stub-prime"]; !ok {
-		values["stub-prime"] = "yes"
+		values["stub-prime"] = "no"
 	}
 	if _, ok := values["stub-first"]; !ok {
 		values["stub-first"] = "yes"


### PR DESCRIPTION
Changed stub-prime default to no if unset. When set to yes, the unbound server requires that the ns records are resolvable before the stub zones will work.