### PR TITLE
Only add TLS related env if TLS enabled.

### DIFF
--- a/api/bases/designate.openstack.org_designates.yaml
+++ b/api/bases/designate.openstack.org_designates.yaml
@@ -2381,6 +2381,9 @@ spec:
                 items:
                   type: string
                 type: array
+              redisTLS:
+                description: RedisTLS - whether the Redis instance has TLS enabled
+                type: string
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string

--- a/api/v1beta1/designate_types.go
+++ b/api/v1beta1/designate_types.go
@@ -283,6 +283,9 @@ type DesignateStatus struct {
 
 	// List of Redis Host IP addresses
 	RedisHostIPs []string `json:"redisHostIPs,omitempty"`
+
+	// RedisTLS - whether the Redis instance has TLS enabled
+	RedisTLS string `json:"redisTLS,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/designate.openstack.org_designates.yaml
+++ b/config/crd/bases/designate.openstack.org_designates.yaml
@@ -2381,6 +2381,9 @@ spec:
                 items:
                   type: string
                 type: array
+              redisTLS:
+                description: RedisTLS - whether the Redis instance has TLS enabled
+                type: string
               transportURLSecret:
                 description: TransportURLSecret - Secret containing RabbitMQ transportURL
                 type: string

--- a/internal/controller/designate_controller.go
+++ b/internal/controller/designate_controller.go
@@ -465,6 +465,30 @@ func (r *DesignateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		return nil
 	}
 
+	// Watch for changes to the Redis CR used by Designate (e.g. TLS config changes)
+	redisWatchFn := func(_ context.Context, o client.Object) []reconcile.Request {
+		designates := &designatev1beta1.DesignateList{}
+		listOpts := []client.ListOption{
+			client.InNamespace(o.GetNamespace()),
+		}
+		if err := r.List(context.Background(), designates, listOpts...); err != nil {
+			Log.Error(err, "Unable to retrieve Designate CRs")
+			return nil
+		}
+		var result []reconcile.Request
+		for _, cr := range designates.Items {
+			if cr.Spec.RedisServiceName == o.GetName() {
+				name := client.ObjectKey{
+					Namespace: o.GetNamespace(),
+					Name:      cr.Name,
+				}
+				Log.Info(fmt.Sprintf("Redis CR %s changed, triggering reconciliation for Designate CR %s", o.GetName(), cr.Name))
+				result = append(result, reconcile.Request{NamespacedName: name})
+			}
+		}
+		return result
+	}
+
 	// TODO(beagles):
 	// - Watch for changes to the redis PODs and resync the headless hostnames for the PODs if necessary.
 	return ctrl.NewControllerManagedBy(mgr).
@@ -481,7 +505,6 @@ func (r *DesignateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		Owns(&corev1.Secret{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&rabbitmqv1.TransportURL{}).
-		Owns(&redisv1.Redis{}).
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.ServiceAccount{}).
@@ -493,6 +516,9 @@ func (r *DesignateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		// Watch for TransportURL Secrets which belong to any TransportURLs created by Designate CRs
 		Watches(&corev1.Secret{},
 			handler.EnqueueRequestsFromMapFunc(transportURLSecretFn)).
+		// Watch for Redis CR changes (e.g. TLS configuration)
+		Watches(&redisv1.Redis{},
+			handler.EnqueueRequestsFromMapFunc(redisWatchFn)).
 		Complete(r)
 }
 
@@ -871,6 +897,12 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 	sort.Strings(hostIPs)
 	instance.Status.RedisHostIPs = hostIPs
 
+	redisTLS, err := isRedisTLS(ctx, instance, helper)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	instance.Status.RedisTLS = fmt.Sprintf("%t", redisTLS)
+
 	instance.Status.Conditions.MarkTrue(condition.InputReadyCondition, condition.InputReadyMessage)
 
 	//
@@ -1127,7 +1159,7 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 				oldHash,
 			)
 
-			_, err := poolUpdatejob.DoJob(ctx, helper)
+			_, err = poolUpdatejob.DoJob(ctx, helper)
 			if err != nil {
 				return ctrl.Result{}, err
 			}
@@ -1733,7 +1765,7 @@ func (r *DesignateReconciler) generateServiceConfigMaps(
 	// TODO(beagles): This should be set to sentinel services! There seems to be a problem with sentinels at them moment.
 	// We should also check for IPv6 validity.
 	backendURL := fmt.Sprintf("redis://%s:6379/", redisIPs[0])
-	if tlsCfg != nil {
+	if instance.Status.RedisTLS == "true" {
 		backendURL = fmt.Sprintf("%s?ssl=true", backendURL)
 	}
 	templateParameters["CoordinationBackendURL"] = backendURL
@@ -2372,4 +2404,17 @@ func getRedisServiceIPs(
 	}
 	// TODO: Ensure that the correct port is exposed
 	return service.Spec.ClusterIPs, nil
+}
+
+func isRedisTLS(
+	ctx context.Context,
+	instance *designatev1beta1.Designate,
+	helper *helper.Helper,
+) (bool, error) {
+	redis := &redisv1.Redis{}
+	err := helper.GetClient().Get(ctx, types.NamespacedName{Name: instance.Spec.RedisServiceName, Namespace: instance.Namespace}, redis)
+	if err != nil {
+		return false, err
+	}
+	return redis.Spec.TLS.SecretName != nil && *redis.Spec.TLS.SecretName != "", nil
 }

--- a/internal/designate/pool_update.go
+++ b/internal/designate/pool_update.go
@@ -83,24 +83,22 @@ func PoolUpdateJob(
 		},
 	)
 
+	envVars := []corev1.EnvVar{}
 	if instance.Spec.DesignateAPI.TLS.CaBundleSecretName != "" {
-		volumes = append(volumes, corev1.Volume{
-			Name: "rabbitmq-certs",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: "cert-rabbitmq-svc",
-				},
-			},
+		volumes = append(volumes, instance.Spec.DesignateAPI.TLS.CreateVolume())
+		volumeMounts = append(volumeMounts, instance.Spec.DesignateAPI.TLS.CreateVolumeMounts(nil)...)
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "SSL_CERT_FILE",
+			Value: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
 		})
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "rabbitmq-certs",
-			MountPath: "/etc/pki/rabbitmq",
-			ReadOnly:  true,
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "SSL_CERT_DIR",
+			Value: "/etc/pki/ca-trust/extracted/pem",
 		})
 	}
 
 	jobName := fmt.Sprintf("%s-pool-update-%d", ServiceName, time.Now().Unix())
-	cmdLine := fmt.Sprintf("/usr/bin/designate-manage --config-file %s --config-file %s pool update --file  /tmp/designate-pools/%s",
+	cmdLine := fmt.Sprintf("/usr/bin/designate-manage --config-file %s --config-file %s pool update --file /tmp/designate-pools/%s",
 		"/var/lib/config-data/default/designate.conf",
 		"/etc/designate/designate.conf",
 		DesignatePoolsYamlPath,
@@ -124,12 +122,7 @@ func PoolUpdateJob(
 						{
 							Name:  jobName,
 							Image: instance.Spec.DesignateCentral.ContainerImage,
-							Env: []corev1.EnvVar{
-								{
-									Name:  "SSL_CERT_FILE",
-									Value: "/etc/pki/rabbitmq/ca.crt",
-								},
-							},
+							Env:   envVars,
 							Command: []string{
 								"/bin/bash",
 								"-c",
@@ -210,19 +203,17 @@ func PoolListJob(
 		},
 	)
 
+	envVars := []corev1.EnvVar{}
 	if instance.Spec.DesignateAPI.TLS.CaBundleSecretName != "" {
-		volumes = append(volumes, corev1.Volume{
-			Name: "rabbitmq-certs",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: "cert-rabbitmq-svc",
-				},
-			},
+		volumes = append(volumes, instance.Spec.DesignateAPI.TLS.CreateVolume())
+		volumeMounts = append(volumeMounts, instance.Spec.DesignateAPI.TLS.CreateVolumeMounts(nil)...)
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "SSL_CERT_FILE",
+			Value: "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
 		})
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      "rabbitmq-certs",
-			MountPath: "/etc/pki/rabbitmq",
-			ReadOnly:  true,
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "SSL_CERT_DIR",
+			Value: "/etc/pki/ca-trust/extracted/pem",
 		})
 	}
 
@@ -255,12 +246,7 @@ func PoolListJob(
 						{
 							Name:  jobName,
 							Image: instance.Spec.DesignateCentral.ContainerImage,
-							Env: []corev1.EnvVar{
-								{
-									Name:  "SSL_CERT_FILE",
-									Value: "/etc/pki/rabbitmq/ca.crt",
-								},
-							},
+							Env:   envVars,
 							Command: []string{
 								"/bin/bash",
 								"-c",

--- a/internal/designate/pools.go
+++ b/internal/designate/pools.go
@@ -118,6 +118,7 @@ func ListPoolsFromJob(
 	// Create job definition following the same pattern as PoolUpdateJob
 	labels := map[string]string{"app": "designate", "job-type": "pool-list"}
 	annotations := map[string]string{}
+
 	jobDef := PoolListJob(instance, labels, annotations)
 
 	// Create and execute the job using lib-common job helper

--- a/test/kuttl/common/validate-pool-update-job.sh
+++ b/test/kuttl/common/validate-pool-update-job.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Verifies the designate-manage pool update Job completed successfully.
+# Job names are designate-pool-update-<unix>. With preserveJobs false, finished Jobs
+# get a TTL and may disappear; then we require status.hash.pool-update on the Designate
+# CR (set only after a successful Job). When multiple Jobs exist, the newest by
+# creationTimestamp must have succeeded so scaling does not pass on a stale Job.
+
+set -euo pipefail
+
+jobs_json=$(oc get -n "$NAMESPACE" jobs -o json)
+pool_jobs=$(echo "$jobs_json" | jq '[.items[] | select(.metadata.name | startswith("designate-pool-update-"))]')
+count=$(echo "$pool_jobs" | jq 'length')
+
+if [ "$count" -eq 0 ]; then
+    pool_hash=$(oc get -n "$NAMESPACE" designate designate -o jsonpath='{.status.hash.pool-update}' 2>/dev/null || true)
+    if [ -n "$pool_hash" ]; then
+        echo "No pool-update Job in namespace (likely TTL); status.hash.pool-update is set on Designate CR"
+        exit 0
+    fi
+    echo "No designate-pool-update-* Job found and status.hash.pool-update is empty"
+    exit 1
+fi
+
+latest=$(echo "$pool_jobs" | jq 'sort_by(.metadata.creationTimestamp) | last')
+name=$(echo "$latest" | jq -r '.metadata.name')
+succeeded=$(echo "$latest" | jq -r '.status.succeeded // 0')
+failed=$(echo "$latest" | jq -r '.status.failed // 0')
+active=$(echo "$latest" | jq -r '.status.active // 0')
+
+if [ "$succeeded" -ge 1 ]; then
+    echo "Pool update Job completed successfully: $name"
+    exit 0
+fi
+
+if [ "$failed" -ge 1 ]; then
+    echo "Pool update Job $name has failures (status.failed=$failed)"
+    exit 1
+fi
+
+if [ "$active" -ge 1 ]; then
+    echo "Pool update Job $name still running (active=$active)"
+    exit 1
+fi
+
+echo "Pool update Job $name not complete yet (succeeded=$succeeded active=$active)"
+exit 1

--- a/test/kuttl/common/validate-predictable-ips.sh
+++ b/test/kuttl/common/validate-predictable-ips.sh
@@ -4,9 +4,10 @@
 #
 # Check Bind9 predictable IPs configmap
 NUM_OF_SERVICES=$1
-bind_ips=$(oc get -n $NAMESPACE configmap designate-bind-ip-map -o json | jq -r '.data | values[]')
+bind_ips=$(oc get -n $NAMESPACE configmap designate-bind-ip-map -o json | jq -r '.data | with_entries(select(.key | test("bind_address_"))) | values[]')
 if [ $(echo "$bind_ips" | wc -l) -ne ${NUM_OF_SERVICES} ]; then
     echo "Expected ${NUM_OF_SERVICES} bind addresses, found $(echo "$bind_ips" | wc -l)"
+    echo "IPS: $bind_ips"
     exit 1
 fi
 for ip in $bind_ips; do
@@ -20,6 +21,7 @@ done
 mdns_ips=$(oc get -n $NAMESPACE configmap designate-mdns-ip-map -o json | jq -r '.data | values[]')
 if [ $(echo "$mdns_ips" | wc -l) -ne ${NUM_OF_SERVICES} ]; then
     echo "Expected ${NUM_OF_SERVICES} mdns addresses, found $(echo "$mdns_ips" | wc -l)"
+    echo "IPS: $mdns_ips"
     exit 1
 fi
 for ip in $mdns_ips; do

--- a/test/kuttl/tests/designate_multipool/09-cleanup.yaml
+++ b/test/kuttl/tests/designate_multipool/09-cleanup.yaml
@@ -6,3 +6,4 @@ commands:
       oc delete configmap designate-multipool-config -n $NAMESPACE
       # Clean up any remaining PVCs from the StatefulSets
       oc delete pvc -l service=designate-backendbind9 -n $NAMESPACE
+      # the predictable IP maps only grow, they do not shrink

--- a/test/kuttl/tests/designate_scale/01-assert.yaml
+++ b/test/kuttl/tests/designate_scale/01-assert.yaml
@@ -175,3 +175,5 @@ commands:
         fi
       done
       exit 0
+  - script: |
+      ../../common/validate-pool-update-job.sh

--- a/test/kuttl/tests/designate_scale/02-assert.yaml
+++ b/test/kuttl/tests/designate_scale/02-assert.yaml
@@ -104,3 +104,4 @@ commands:
   - script: |
       ../../common/validate-predictable-ips.sh 3
       ../../common/validate-pools-yaml.sh 3
+      ../../common/validate-pool-update-job.sh

--- a/test/kuttl/tests/designate_scale/03-assert.yaml
+++ b/test/kuttl/tests/designate_scale/03-assert.yaml
@@ -104,3 +104,4 @@ commands:
   - script: |
       ../../common/validate-predictable-ips.sh 1
       ../../common/validate-pools-yaml.sh 1
+      ../../common/validate-pool-update-job.sh

--- a/test/kuttl/tests/designate_scale/04-assert.yaml
+++ b/test/kuttl/tests/designate_scale/04-assert.yaml
@@ -106,3 +106,4 @@ commands:
   - script: |
       ../../common/validate-predictable-ips.sh 3
       ../../common/validate-pools-yaml.sh 3
+      ../../common/validate-pool-update-job.sh


### PR DESCRIPTION
Fixes some TLS flexibility issues
    
Sets up the pool jobs and the redis URL to work whether TLS is enabled or not (previously assumed tls was always enabled).
    
Also fixes a redis instance monitoring bug.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>