### PR TITLE
Replace hardcoded NS in KUTTL with  variable

### DIFF
--- a/test/kuttl/common/assert-sample-deployment.yaml
+++ b/test/kuttl/common/assert-sample-deployment.yaml
@@ -29,7 +29,6 @@ status:
   designateProducerReadyCount: 1
   designateUnboundReadyCount: 1
   designateWorkerReadyCount: 1
-  databaseHostname: openstack.designate-kuttl-tests.svc
   conditions:
   - message: Setup complete
     reason: Ready
@@ -139,6 +138,14 @@ spec:
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
+  - script: |
+      dbHostTemplate='{{.status.databaseHostname}}'
+      dbHostname=$(oc get -n $NAMESPACE Designate designate -o go-template="$dbHostTemplate")
+      expectedDbHostname="openstack.$NAMESPACE.svc"
+      if [ "$dbHostname" != "$expectedDbHostname" ]; then
+        echo "databaseHostname mismatch: got '$dbHostname', expected '$expectedDbHostname'"
+        exit 1
+      fi
   - script: |
       template='{{.spec.endpoints.internal}}{{":"}}{{.spec.endpoints.public}}{{"\n"}}'
       regex="http:\/\/designate-internal.$NAMESPACE.*:http:\/\/designate-public.$NAMESPACE.*"

--- a/test/kuttl/tests/basic/01-assert.yaml
+++ b/test/kuttl/tests/basic/01-assert.yaml
@@ -29,7 +29,6 @@ status:
   designateProducerReadyCount: 1
   designateUnboundReadyCount: 1
   designateWorkerReadyCount: 1
-  databaseHostname: openstack.designate-kuttl-tests.svc
   conditions:
   - message: Setup complete
     reason: Ready
@@ -135,6 +134,14 @@ spec:
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
+  - script: |
+      dbHostTemplate='{{.status.databaseHostname}}'
+      dbHostname=$(oc get -n $NAMESPACE Designate designate -o go-template="$dbHostTemplate")
+      expectedDbHostname="openstack.$NAMESPACE.svc"
+      if [ "$dbHostname" != "$expectedDbHostname" ]; then
+        echo "databaseHostname mismatch: got '$dbHostname', expected '$expectedDbHostname'"
+        exit 1
+      fi
   - script: |
       tupleTemplate='{{ range (index .spec.template.spec.containers 0).env }}{{ .name }}{{ "#" }}{{ .value}}{{"\n"}}{{ end }}'
       imageTuples=$(oc get -n openstack-operators deployment designate-operator-controller-manager -o go-template="$tupleTemplate")

--- a/test/kuttl/tests/designate_scale/01-assert.yaml
+++ b/test/kuttl/tests/designate_scale/01-assert.yaml
@@ -29,7 +29,6 @@ status:
   designateProducerReadyCount: 1
   designateUnboundReadyCount: 1
   designateWorkerReadyCount: 1
-  databaseHostname: openstack.designate-kuttl-tests.svc
   conditions:
   - message: Setup complete
     reason: Ready
@@ -136,6 +135,14 @@ spec:
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
+  - script: |
+      dbHostTemplate='{{.status.databaseHostname}}'
+      dbHostname=$(oc get -n $NAMESPACE Designate designate -o go-template="$dbHostTemplate")
+      expectedDbHostname="openstack.$NAMESPACE.svc"
+      if [ "$dbHostname" != "$expectedDbHostname" ]; then
+        echo "databaseHostname mismatch: got '$dbHostname', expected '$expectedDbHostname'"
+        exit 1
+      fi
   - script: |
       tupleTemplate='{{ range (index .spec.template.spec.containers 0).env }}{{ .name }}{{ "#" }}{{ .value}}{{"\n"}}{{ end }}'
       imageTuples=$(oc get -n openstack-operators deployment designate-operator-controller-manager -o go-template="$tupleTemplate")


### PR DESCRIPTION
DESIGNATE_KUTTL_NAMESPACE is user-configurable in install_yamls (via ?= assignment), but test scripts and asserts had "designate-kuttl-tests" hardcoded in databaseHostname assertions. Tests would fail when run with a non-default namespace.

Replace all hardcoded namespace references with the $NAMESPACE env var that KUTTL provides to test scripts. Specifically, for databaseHostname validation, switch from static YAML asserts to script-based checks that dynamically construct the expected value.

Co-Authored-By: Claude Opus 4.6 [noreply@anthropic.com](mailto:noreply@anthropic.com)