### PR TITLE
Add predictable IP support for Unbound

### DIFF
--- a/api/bases/designate.openstack.org_designates.yaml
+++ b/api/bases/designate.openstack.org_designates.yaml
@@ -1638,6 +1638,9 @@ spec:
                       ConfigOverwrite - interface to overwrite default config files like e.g. policy.json.
                       But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                     type: object
+                  netUtilsImage:
+                    description: NetUtilsImage - NetUtils container image
+                    type: string
                   networkAttachments:
                     description: NetworkAttachments is a list of NetworkAttachment
                       resource names to expose the services to the given network

--- a/api/bases/designate.openstack.org_designateunbounds.yaml
+++ b/api/bases/designate.openstack.org_designateunbounds.yaml
@@ -73,6 +73,9 @@ spec:
                   ConfigOverwrite - interface to overwrite default config files like e.g. policy.json.
                   But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                 type: object
+              netUtilsImage:
+                description: NetUtilsImage - NetUtils container image
+                type: string
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
                   names to expose the services to the given network

--- a/api/v1beta1/designate_webhook.go
+++ b/api/v1beta1/designate_webhook.go
@@ -98,6 +98,9 @@ func (spec *DesignateSpec) Default() {
 	if spec.DesignateUnbound.ContainerImage == "" {
 		spec.DesignateUnbound.ContainerImage = designateDefaults.UnboundContainerImageURL
 	}
+	if spec.DesignateUnbound.NetUtilsImage == "" {
+		spec.DesignateUnbound.NetUtilsImage = designateDefaults.NetUtilsURL
+	}
 }
 
 func (spec *DesignateSpecBase) Default() {

--- a/api/v1beta1/designateunbound_types.go
+++ b/api/v1beta1/designateunbound_types.go
@@ -47,6 +47,10 @@ type DesignateUnboundSpecBase struct {
 	ServiceAccount string `json:"serviceAccount"`
 
 	// +kubebuilder:validation:Optional
+	// NetUtilsImage - NetUtils container image
+	NetUtilsImage string `json:"netUtilsImage"`
+
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Maximum=32
 	// +kubebuilder:validation:Minimum=0

--- a/config/crd/bases/designate.openstack.org_designates.yaml
+++ b/config/crd/bases/designate.openstack.org_designates.yaml
@@ -1638,6 +1638,9 @@ spec:
                       ConfigOverwrite - interface to overwrite default config files like e.g. policy.json.
                       But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                     type: object
+                  netUtilsImage:
+                    description: NetUtilsImage - NetUtils container image
+                    type: string
                   networkAttachments:
                     description: NetworkAttachments is a list of NetworkAttachment
                       resource names to expose the services to the given network

--- a/config/crd/bases/designate.openstack.org_designateunbounds.yaml
+++ b/config/crd/bases/designate.openstack.org_designateunbounds.yaml
@@ -73,6 +73,9 @@ spec:
                   ConfigOverwrite - interface to overwrite default config files like e.g. policy.json.
                   But can also be used to add additional files. Those get added to the service config dir in /etc/<service> .
                 type: object
+              netUtilsImage:
+                description: NetUtilsImage - NetUtils container image
+                type: string
               networkAttachments:
                 description: NetworkAttachments is a list of NetworkAttachment resource
                   names to expose the services to the given network

--- a/internal/controller/designate_controller.go
+++ b/internal/controller/designate_controller.go
@@ -1172,12 +1172,22 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 		return ctrl.Result{}, err
 	}
 
+	// Handle Unbound predictable IPs configmap
+	unboundLabels := labels.GetLabels(instance, labels.GetGroupLabel(instance.Name), map[string]string{})
+	unboundConfigMap, err := r.handleConfigMap(ctx, helper, instance, designate.UnboundPredIPConfigMap, unboundLabels)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	allocatedIPs := make(map[string]bool)
 	for _, key := range slices.Sorted(maps.Keys(bindConfigMap.Data)) {
 		allocatedIPs[bindConfigMap.Data[key]] = true
 	}
 	for _, key := range slices.Sorted(maps.Keys(mdnsConfigMap.Data)) {
 		allocatedIPs[mdnsConfigMap.Data[key]] = true
+	}
+	for _, key := range slices.Sorted(maps.Keys(unboundConfigMap.Data)) {
+		allocatedIPs[unboundConfigMap.Data[key]] = true
 	}
 
 	// Handle Mdns predictable IPs configmap
@@ -1221,7 +1231,7 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 		bindNames = append(bindNames, fmt.Sprintf("bind_address_%d", i))
 	}
 
-	updatedBindMap, _, err := r.allocatePredictableIPs(ctx, predictableIPParams, bindNames, bindConfigMap.Data, allocatedIPs)
+	updatedBindMap, allocatedIPs, err := r.allocatePredictableIPs(ctx, predictableIPParams, bindNames, bindConfigMap.Data, allocatedIPs)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -1230,6 +1240,27 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 	ctrlResult, err = r.reconcileBindConfigMaps(ctx, instance, helper, multipoolConfig, updatedBindMap, bindLabels)
 	if err != nil || (ctrlResult != ctrl.Result{}) {
 		return ctrlResult, err
+	}
+
+	unboundReplicaCount := int(*instance.Spec.DesignateUnbound.Replicas)
+	var unboundNames []string
+	for i := 0; i < unboundReplicaCount; i++ {
+		unboundNames = append(unboundNames, fmt.Sprintf("unbound_address_%d", i))
+	}
+
+	updatedUnboundMap, _, err := r.allocatePredictableIPs(ctx, predictableIPParams, unboundNames, unboundConfigMap.Data, allocatedIPs)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	_, err = controllerutil.CreateOrPatch(ctx, helper.GetClient(), unboundConfigMap, func() error {
+		unboundConfigMap.Labels = util.MergeStringMaps(unboundConfigMap.Labels, unboundLabels)
+		unboundConfigMap.Data = updatedUnboundMap
+		return controllerutil.SetControllerReference(instance, unboundConfigMap, helper.GetScheme())
+	})
+	if err != nil {
+		Log.Info("Unable to create config map for unbound ips...")
+		return ctrl.Result{}, err
 	}
 
 	if len(nsRecords) > 0 && instance.Status.DesignateCentralReadyCount > 0 {

--- a/internal/controller/designateunbound_controller.go
+++ b/internal/controller/designateunbound_controller.go
@@ -503,6 +503,16 @@ func (r *UnboundReconciler) reconcileNormal(ctx context.Context, instance *desig
 		// by comparing it with the ObservedGeneration.
 		if statefulset.IsReady(deploy) {
 			instance.Status.Conditions.MarkTrue(condition.DeploymentReadyCondition, condition.DeploymentReadyMessage)
+
+			// Handle pod labeling for predictable IPs when statefulset is ready
+			config := designate.PodLabelingConfig{
+				ConfigMapName: designate.UnboundPredIPConfigMap,
+				IPKeyPrefix:   "unbound_address_",
+			}
+			err = designate.HandlePodLabeling(ctx, helper, instance.Name, instance.Namespace, config)
+			if err != nil {
+				Log.Error(err, "Failed to handle pod labeling")
+			}
 		} else {
 			instance.Status.Conditions.Set(condition.FalseCondition(
 				condition.DeploymentReadyCondition,
@@ -667,6 +677,18 @@ func (r *UnboundReconciler) generateServiceConfigMaps(
 	templateParameters["AllowCidrs"] = allowCidrs
 
 	cms := []util.Template{
+		// ScriptsConfigMap
+		{
+			Name:         designate.ScriptsVolumeName(instance.Name),
+			Namespace:    instance.Namespace,
+			Type:         util.TemplateTypeScripts,
+			InstanceType: instance.Kind,
+			AdditionalTemplate: map[string]string{
+				"setipalias.py": "/common/setipalias.py",
+				"setipalias.sh": "/designateunbound/bin/setipalias.sh",
+			},
+			Labels: cmLabels,
+		},
 		// ConfigMap
 		{
 			Name:          designate.ConfigVolumeName(instance.Name),

--- a/internal/designate/const.go
+++ b/internal/designate/const.go
@@ -54,6 +54,9 @@ const (
 	// BindPredIPConfigMap is the name of the ConfigMap containing bind predictable IP mappings
 	BindPredIPConfigMap = "designate-bind-ip-map"
 
+	// UnboundPredIPConfigMap is the name of the ConfigMap containing Unbound predictable IP mappings
+	UnboundPredIPConfigMap = "designate-unbound-ip-map"
+
 	// RndcConfDir is the directory path for RNDC configuration files
 	RndcConfDir = "/etc/designate/rndc-keys"
 

--- a/internal/designateunbound/statefulset.go
+++ b/internal/designateunbound/statefulset.go
@@ -31,10 +31,6 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-const (
-	configVolume = "designateunbound-config"
-)
-
 // StatefulSet func
 func StatefulSet(instance *designatev1beta1.DesignateUnbound,
 	configHash string,
@@ -42,26 +38,18 @@ func StatefulSet(instance *designatev1beta1.DesignateUnbound,
 	annotations map[string]string,
 	topology *topologyv1.Topology,
 ) *appsv1.StatefulSet {
-	var configMode int32 = 0640
 
-	volumes := []corev1.Volume{
-		{
-			Name: configVolume,
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					DefaultMode: &configMode,
-					SecretName:  fmt.Sprintf("%s-config-data", instance.Name),
-				},
-			},
-		},
+	volumeDefs := []designate.VolumeMapping{
+		{Name: designate.ScriptsVolumeName(instance.Name), Type: designate.ScriptMount, MountPath: "/usr/local/bin/container-scripts"},
+		{Name: designate.ConfigVolumeName(instance.Name), Type: designate.SecretMount, MountPath: "/etc/unbound/conf.d"},
 	}
-	mounts := []corev1.VolumeMount{
-		{
-			Name:      configVolume,
-			MountPath: "/etc/unbound/conf.d",
-			ReadOnly:  true,
-		},
+	if instance.Spec.NetUtilsImage != "" && len(instance.Spec.NetworkAttachments) > 0 {
+		volumeDefs = append(volumeDefs, designate.VolumeMapping{
+			Name: designate.UnboundPredIPConfigMap, Type: designate.ConfigMount, MountPath: "/var/lib/predictableips",
+		})
 	}
+
+	volumes, initVolumeMounts := designate.ProcessVolumes(volumeDefs)
 
 	livenessProbe := &corev1.Probe{
 		// TODO might need tuning
@@ -131,7 +119,7 @@ func StatefulSet(instance *designatev1beta1.DesignateUnbound,
 							RunAsUser: ptr.To[int64](0),
 						},
 						Env:            env.MergeEnvs([]corev1.EnvVar{}, envVars),
-						VolumeMounts:   mounts,
+						VolumeMounts:   initVolumeMounts,
 						Resources:      instance.Spec.Resources,
 						ReadinessProbe: readinessProbe,
 						LivenessProbe:  livenessProbe,
@@ -162,5 +150,23 @@ func StatefulSet(instance *designatev1beta1.DesignateUnbound,
 			corev1.LabelHostname,
 		)
 	}
+
+	if instance.Spec.NetUtilsImage != "" && len(instance.Spec.NetworkAttachments) > 0 {
+		envVars = map[string]env.Setter{}
+		envVars["POD_NAME"] = env.DownwardAPI("metadata.name")
+		envVars["MAP_PREFIX"] = env.SetValue("unbound_address_")
+		podEnv := env.MergeEnvs([]corev1.EnvVar{}, envVars)
+		predIPContainerDetails := designate.PredIPContainerDetails{
+			ContainerImage: instance.Spec.NetUtilsImage,
+			VolumeMounts:   initVolumeMounts,
+			EnvVars:        podEnv,
+			Command:        designate.PredictableIPCommand,
+		}
+
+		statefulSet.Spec.Template.Spec.InitContainers = []corev1.Container{
+			designate.PredictableIPContainer(predIPContainerDetails),
+		}
+	}
+
 	return statefulSet
 }

--- a/templates/designateunbound/bin/setipalias.sh
+++ b/templates/designateunbound/bin/setipalias.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Copyright 2024 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+set -ex
+
+/usr/local/bin/container-scripts/setipalias.py

--- a/test/functional/designate_controller_test.go
+++ b/test/functional/designate_controller_test.go
@@ -638,7 +638,7 @@ var _ = Describe("Designate controller", func() {
 			}
 		})
 
-		It("should create ConfigMaps for Bind9 and Mdns predictable IPs", func() {
+		It("should create ConfigMaps for Bind9, Mdns and Unbound predictable IPs", func() {
 			bindConfigMap := th.GetConfigMap(types.NamespacedName{
 				Name:      designate.BindPredIPConfigMap,
 				Namespace: namespace})
@@ -686,6 +686,23 @@ var _ = Describe("Designate controller", func() {
 				Expect(ip).NotTo(BeNil(), "Invalid IP format: %s", ipAddress)
 
 				// check there are no duplicate IPs
+				Expect(usedIPs[ipAddress]).To(BeFalse(), "Duplicate IP found: %s", ipAddress)
+				usedIPs[ipAddress] = true
+			}
+
+			unboundConfigMap := th.GetConfigMap(types.NamespacedName{
+				Name:      designate.UnboundPredIPConfigMap,
+				Namespace: namespace})
+			Expect(unboundConfigMap.Data).To(HaveLen(unboundReplicaCount))
+			for key, ipAddress := range unboundConfigMap.Data {
+				// verify key with unbound_address_N format
+				Expect(key).To(MatchRegexp(`^unbound_address_\d+$`))
+
+				// verify valid IP format
+				ip := net.ParseIP(ipAddress)
+				Expect(ip).NotTo(BeNil(), "Invalid IP format: %s", ipAddress)
+
+				// check there are no duplicate IPs across all services
 				Expect(usedIPs[ipAddress]).To(BeFalse(), "Duplicate IP found: %s", ipAddress)
 				usedIPs[ipAddress] = true
 			}

--- a/test/kuttl/common/validate-predictable-ips.sh
+++ b/test/kuttl/common/validate-predictable-ips.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# This is a base script which will verify Bind9 & Mdns predictable IPs.
+# This is a base script which will verify Bind9, Mdns & Unbound predictable IPs.
 #
 # Check Bind9 predictable IPs configmap
 NUM_OF_SERVICES=$1
@@ -30,4 +30,18 @@ for ip in $mdns_ips; do
         exit 1
     fi
 done
-echo "Bind9 & Mdns predictable IPs were verified successfully"
+
+# Check Unbound predictable IPs configmap
+unbound_ips=$(oc get -n $NAMESPACE configmap designate-unbound-ip-map -o json | jq -r '.data | with_entries(select(.key | test("unbound_address_"))) | values[]')
+if [ $(echo "$unbound_ips" | wc -l) -ne ${NUM_OF_SERVICES} ]; then
+    echo "Expected ${NUM_OF_SERVICES} unbound addresses, found $(echo "$unbound_ips" | wc -l)"
+    echo "IPS: $unbound_ips"
+    exit 1
+fi
+for ip in $unbound_ips; do
+    if [[ ! $ip =~ ^172\.28\.0\.[0-9]+$ ]]; then
+        echo "Invalid unbound IP format: $ip"
+        exit 1
+    fi
+done
+echo "Bind9, Mdns & Unbound predictable IPs were verified successfully"


### PR DESCRIPTION
Enable predictable IP allocation for Unbound pods, using the same mechanism as mDNS and BIND. Unbound IPs are allocated last in the chain (mDNS → BIND → Unbound) to avoid disrupting existing assignments on upgrades.

Adds NetUtilsImage field to DesignateUnboundSpecBase, a predictableips init container to the Unbound StatefulSet, and the designate-unbound-ip-map ConfigMap managed by the parent controller. Unbound does not need a designate.conf init container since it uses its own unbound.conf configuration.