### PR TITLE
Support external bind information (mounting rndc keys only)

### DIFF
--- a/api/bases/designate.openstack.org_designates.yaml
+++ b/api/bases/designate.openstack.org_designates.yaml
@@ -2098,6 +2098,10 @@ spec:
                 required:
                 - containerImage
                 type: object
+              externalBindsSecret:
+                description: ExternalBindsSecret is the name of the secret containing
+                  external BIND9 configurations
+                type: string
               messagingBus:
                 description: MessagingBus configuration (cluster, username, and vhost)
                 properties:

--- a/api/v1beta1/designate_types.go
+++ b/api/v1beta1/designate_types.go
@@ -231,6 +231,10 @@ type DesignateSpecBase struct {
 	// +listType=atomic
 	// NSRecords contains the list of nameserver records for the Designate pool
 	NSRecords []DesignateNSRecord `json:"nsRecords,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// ExternalBindsSecret is the name of the secret containing external BIND9 configurations
+	ExternalBindsSecret string `json:"externalBindsSecret,omitempty"`
 }
 
 // DesignateStatus defines the observed state of Designate

--- a/config/crd/bases/designate.openstack.org_designates.yaml
+++ b/config/crd/bases/designate.openstack.org_designates.yaml
@@ -2098,6 +2098,10 @@ spec:
                 required:
                 - containerImage
                 type: object
+              externalBindsSecret:
+                description: ExternalBindsSecret is the name of the secret containing
+                  external BIND9 configurations
+                type: string
               messagingBus:
                 description: MessagingBus configuration (cluster, username, and vhost)
                 properties:

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260518125357-72bdd580c587
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20260421135251-4fb605db7d18
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.31.14
 	k8s.io/apimachinery v0.31.14
 	k8s.io/client-go v0.31.14
@@ -108,7 +109,6 @@ require (
 	google.golang.org/protobuf v1.36.7 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.33.2 // indirect
 	k8s.io/apiserver v0.33.2 // indirect
 	k8s.io/component-base v0.33.2 // indirect

--- a/internal/controller/designate_controller.go
+++ b/internal/controller/designate_controller.go
@@ -31,10 +31,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
@@ -488,6 +490,36 @@ func (r *DesignateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		return result
 	}
 
+	externalBindsFn := func(_ context.Context, o client.Object) []reconcile.Request {
+		result := []reconcile.Request{}
+
+		var namespace = o.GetNamespace()
+		var secretName = o.GetName()
+
+		designates := &designatev1beta1.DesignateList{}
+		listOpts := []client.ListOption{
+			client.InNamespace(namespace),
+		}
+		if err := r.List(context.Background(), designates, listOpts...); err != nil {
+			Log.Error(err, "Unable to retrieve Designate CRs")
+			return nil
+		}
+
+		for _, cr := range designates.Items {
+			if cr.Spec.ExternalBindsSecret == secretName || secretName == designate.ExternalBindsData {
+				name := client.ObjectKey{
+					Namespace: namespace,
+					Name:      cr.Name,
+				}
+				result = append(result, reconcile.Request{NamespacedName: name})
+			}
+		}
+		if len(result) > 0 {
+			return result
+		}
+		return nil
+	}
+
 	// TODO(beagles):
 	// - Watch for changes to the redis PODs and resync the headless hostnames for the PODs if necessary.
 	return ctrl.NewControllerManagedBy(mgr).
@@ -510,14 +542,27 @@ func (r *DesignateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
 		// Watch for multipool ConfigMap changes to regenerate pools.yaml
-		Watches(&corev1.ConfigMap{},
-			handler.EnqueueRequestsFromMapFunc(r.findDesignatesForMultipoolConfigMap)).
+		Watches(
+			&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(r.findDesignatesForMultipoolConfigMap),
+		).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(externalBindsFn),
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+		).
 		// Watch for TransportURL Secrets which belong to any TransportURLs created by Designate CRs
-		Watches(&corev1.Secret{},
-			handler.EnqueueRequestsFromMapFunc(transportURLSecretFn)).
+		Watches(
+			&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(transportURLSecretFn),
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+		).
 		// Watch for Redis CR changes (e.g. TLS configuration)
-		Watches(&redisv1.Redis{},
-			handler.EnqueueRequestsFromMapFunc(redisWatchFn)).
+		Watches(
+			&redisv1.Redis{},
+			handler.EnqueueRequestsFromMapFunc(redisWatchFn),
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+		).
 		Complete(r)
 }
 
@@ -970,6 +1015,97 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 		Log.Info(fmt.Sprintf("Deployment %s successfully reconciled - operation: %s", instance.Name, string(op)))
 	}
 	Log.Info("Deployment API task reconciled")
+
+	// Check for external BIND9 configurations.
+	// Note: We can't use getSecret() here as the absence of the secret just means there are
+	// no external binds defined, which is not an error. We need this secret's data
+	// for the pool generator and to create an extra secret for the RNDC keys.
+	// Also note: This is a little problematic with respect to optimization. Any time this
+	// changes we need to:
+	// - rebuild the mountable rndc secret for the workers
+	// - restart the workers ... we should really be starting workers along with mDNS before
+	//   any other designate component.
+	// - regenerate the pools
+
+	externalBindData := make(map[string][]designate.ExternalBind)
+	externalRndcSecretData := make(map[string]string)
+	updateRndcSecret := true
+
+	if instance.Spec.ExternalBindsSecret != "" {
+		externalBindsSecret, hash, err := oko_secret.GetSecret(ctx, helper, instance.Spec.ExternalBindsSecret, instance.Namespace)
+		if err != nil {
+			if k8s_errors.IsNotFound(err) {
+				instance.Status.Conditions.Set(condition.FalseCondition(
+					condition.InputReadyCondition,
+					condition.ErrorReason,
+					condition.SeverityWarning,
+					condition.InputReadyErrorMessage,
+					fmt.Sprintf("External Binds Secret %s not found", instance.Spec.ExternalBindsSecret)))
+				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+			}
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				condition.InputReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				condition.InputReadyErrorMessage,
+				err.Error()))
+			return ctrl.Result{}, err
+		}
+
+		if hash != instance.Status.Hash[designate.ExternalBindsData] {
+			// We only care about the data for the default pool at the moment,
+			// but let's accommodate all for the BYOB case in the future.
+			for poolName, data := range externalBindsSecret.Data {
+				externalBinds, err := designate.ReadExternalBinds(data)
+				if err != nil {
+					instance.Status.Conditions.Set(condition.FalseCondition(
+						condition.InputReadyCondition,
+						condition.ErrorReason,
+						condition.SeverityWarning,
+						condition.InputReadyErrorMessage,
+						err.Error()))
+					return ctrl.Result{}, err
+				}
+				externalBindData[poolName] = externalBinds
+				for i, bind := range externalBinds {
+					rndcBlock := fmt.Sprintf(
+						"key \"%s\" {\n\talgorithm %s;\n\tsecret \"%s\";\n};",
+						bind.RndcKeyName, bind.RndcAlgorithm, bind.RndcSecret,
+					)
+					externalRndcSecretData[fmt.Sprintf("%s-rndc-%d", poolName, i)] = rndcBlock
+				}
+			}
+			instance.Status.Hash[designate.ExternalBindsData] = hash
+		} else {
+			// if the hash is the same, we don't need to update the rndc secret
+			updateRndcSecret = false
+		}
+	} else {
+		instance.Status.Hash[designate.ExternalBindsData] = ""
+	}
+
+	if updateRndcSecret {
+		// Update the rndc secret data
+		labels := labels.GetLabels(instance, labels.GetGroupLabel(instance.Name), map[string]string{})
+		rndcKeySecretData := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      designate.ExternalRndcData,
+				Namespace: instance.Namespace,
+				Labels:    labels,
+			},
+			StringData: externalRndcSecretData,
+		}
+		_, _, err = oko_secret.CreateOrPatchSecret(ctx, helper, instance, rndcKeySecretData)
+		if err != nil {
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				condition.InputReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				condition.InputReadyErrorMessage,
+				err.Error()))
+			return ctrl.Result{}, err
+		}
+	}
 
 	// Get multipool configuration once for use in bind IP allocation and pools.yaml generation
 	multipoolConfig, err := designate.GetMultipoolConfig(ctx, helper.GetClient(), instance.Namespace)

--- a/internal/controller/designateworker_controller.go
+++ b/internal/controller/designateworker_controller.go
@@ -285,6 +285,15 @@ func (r *DesignateWorkerReconciler) SetupWithManager(ctx context.Context, mgr ct
 					result = append(result, reconcile.Request{NamespacedName: name})
 				}
 			}
+			// the rndc secret is a computed secret with a fixed name so we can just check by constant.
+			if secretName == designate.ExternalRndcData {
+				name := client.ObjectKey{
+					Namespace: namespace,
+					Name:      cr.Name,
+				}
+				Log.Info(fmt.Sprintf("Secret %s is used by Designate CR %s", secretName, cr.Name))
+				result = append(result, reconcile.Request{NamespacedName: name})
+			}
 		}
 		if len(result) > 0 {
 			return result
@@ -668,6 +677,7 @@ func (r *DesignateWorkerReconciler) reconcileNormal(ctx context.Context, instanc
 	//
 
 	// Define a new Deployment object
+
 	deplDef := designateworker.Deployment(instance, inputHash, serviceLabels, serviceAnnotations, topology)
 	depl := deployment.NewDeployment(
 		deplDef,
@@ -862,8 +872,29 @@ func (r *DesignateWorkerReconciler) createHashOfInputHashes(
 	if err != nil {
 		return secretHash, changed, err
 	}
-
 	envVars[designate.DesignateBindKeySecret] = env.SetValue(secretHash)
+
+	// Make sure we redeploy if the secret changes
+	extraRndcSecret := &corev1.Secret{}
+	err = h.GetClient().Get(ctx, types.NamespacedName{
+		Name:      designate.ExternalRndcData,
+		Namespace: instance.Namespace,
+	}, extraRndcSecret)
+
+	if err != nil {
+		if k8s_errors.IsNotFound(err) {
+			Log.Error(err, "Unable to retrieve extra rndc key - may not be an error")
+		} else {
+			return "", false, err
+		}
+	} else {
+		extraRndcSecretHash, err := secret.Hash(extraRndcSecret)
+		if err != nil {
+			return extraRndcSecretHash, changed, err
+		}
+		envVars[designate.ExternalRndcData] = env.SetValue(extraRndcSecretHash)
+	}
+
 	mergedMapVars := env.MergeEnvs([]corev1.EnvVar{}, envVars)
 	hash, err := util.ObjectHash(mergedMapVars)
 	if err != nil {

--- a/internal/designate/const.go
+++ b/internal/designate/const.go
@@ -104,4 +104,11 @@ const (
 
 	// ACConsumerFinalizer is added to AC secrets that designate is actively consuming
 	ACConsumerFinalizer = "openstack.org/designateapi-ac-consumer"
+
+	// ExternalBindsData is the name of the secret containing external BIND9 configurations
+	ExternalBindsData = "designate-external-binds"
+
+	// ExternalRndcData is the name of the secret for mounting the external binds rndc keys
+	// in the workers.
+	ExternalRndcData = "designate-external-rndc"
 )

--- a/internal/designate/external_binds_reader.go
+++ b/internal/designate/external_binds_reader.go
@@ -1,0 +1,68 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package designate
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+// ExternalBind defines connection parameters for a BIND9 instance not managed by this operator.
+type ExternalBind struct {
+	Name          string  `yaml:"name"`
+	Address       string  `yaml:"address"`
+	Port          int     `yaml:"port"`
+	RndcHost      *string `yaml:"rndchost,omitempty"`
+	RndcKeyName   string  `yaml:"rndckeyname"`
+	RndcAlgorithm string  `yaml:"rndcalgorithm"`
+	RndcSecret    string  `yaml:"rndcsecret"`
+	RndcPort      int     `yaml:"rndcport"`
+}
+
+const (
+	// DefaultRndcKeyName is the BIND9 key clause name used when rndckeyname is omitted.
+	DefaultRndcKeyName = "rndc-key"
+	// DefaultRndcAlgorithm is the TSIG algorithm used when rndcalgorithm is omitted.
+	DefaultRndcAlgorithm = "hmac-sha256"
+)
+
+// ReadExternalBinds unmarshals a YAML array of ExternalBind entries and applies
+// defaults for omitted fields: Port (53), RndcPort (953), RndcKeyName ("rndc-key"),
+// and RndcAlgorithm ("hmac-sha256").
+func ReadExternalBinds(data []byte) ([]ExternalBind, error) {
+	externalBinds := []ExternalBind{}
+
+	err := yaml.Unmarshal(data, &externalBinds)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range externalBinds {
+		if externalBinds[i].Port == 0 {
+			externalBinds[i].Port = DNSPort
+		}
+		if externalBinds[i].RndcPort == 0 {
+			externalBinds[i].RndcPort = RNDCPort
+		}
+		if externalBinds[i].RndcKeyName == "" {
+			externalBinds[i].RndcKeyName = DefaultRndcKeyName
+		}
+		if externalBinds[i].RndcAlgorithm == "" {
+			externalBinds[i].RndcAlgorithm = DefaultRndcAlgorithm
+		}
+	}
+
+	return externalBinds, nil
+}

--- a/internal/designate/external_binds_reader_test.go
+++ b/internal/designate/external_binds_reader_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package designate
+
+import (
+	"testing"
+)
+
+func TestReadExternalBinds(t *testing.T) {
+	rndcHost := "10.0.0.99"
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    []ExternalBind
+		expectError bool
+	}{
+		{
+			name: "all fields specified",
+			input: `
+- name: bind9-primary
+  address: 192.168.1.10
+  port: 5353
+  rndchost: 10.0.0.99
+  rndckeyname: my-custom-key
+  rndcalgorithm: hmac-sha512
+  rndcsecret: c2VjcmV0MTIz
+  rndcport: 1953
+`,
+			expected: []ExternalBind{
+				{
+					Name:          "bind9-primary",
+					Address:       "192.168.1.10",
+					Port:          5353,
+					RndcHost:      &rndcHost,
+					RndcKeyName:   "my-custom-key",
+					RndcAlgorithm: "hmac-sha512",
+					RndcSecret:    "c2VjcmV0MTIz",
+					RndcPort:      1953,
+				},
+			},
+		},
+		{
+			name: "defaults applied for omitted fields",
+			input: `
+- name: bind9-minimal
+  address: 192.168.1.10
+  rndcsecret: c2VjcmV0MTIz
+`,
+			expected: []ExternalBind{
+				{
+					Name:          "bind9-minimal",
+					Address:       "192.168.1.10",
+					Port:          DNSPort,
+					RndcHost:      nil,
+					RndcKeyName:   DefaultRndcKeyName,
+					RndcAlgorithm: DefaultRndcAlgorithm,
+					RndcSecret:    "c2VjcmV0MTIz",
+					RndcPort:      RNDCPort,
+				},
+			},
+		},
+		{
+			name: "multiple entries with mixed defaults",
+			input: `
+- name: primary
+  address: 192.168.1.10
+  port: 5353
+  rndcsecret: c2VjcmV0MQ==
+- name: secondary
+  address: 192.168.1.11
+  rndchost: 10.0.0.99
+  rndckeyname: custom-key
+  rndcsecret: c2VjcmV0Mg==
+`,
+			expected: []ExternalBind{
+				{
+					Name:          "primary",
+					Address:       "192.168.1.10",
+					Port:          5353,
+					RndcHost:      nil,
+					RndcKeyName:   DefaultRndcKeyName,
+					RndcAlgorithm: DefaultRndcAlgorithm,
+					RndcSecret:    "c2VjcmV0MQ==",
+					RndcPort:      RNDCPort,
+				},
+				{
+					Name:          "secondary",
+					Address:       "192.168.1.11",
+					Port:          DNSPort,
+					RndcHost:      &rndcHost,
+					RndcKeyName:   "custom-key",
+					RndcAlgorithm: DefaultRndcAlgorithm,
+					RndcSecret:    "c2VjcmV0Mg==",
+					RndcPort:      RNDCPort,
+				},
+			},
+		},
+		{
+			name:     "empty input",
+			input:    "",
+			expected: []ExternalBind{},
+		},
+		{
+			name:     "empty array",
+			input:    "[]",
+			expected: []ExternalBind{},
+		},
+		{
+			name:        "invalid yaml",
+			input:       "not: valid: yaml: [list",
+			expectError: true,
+		},
+		{
+			name:        "wrong type - object instead of array",
+			input:       "name: single\naddress: 192.168.1.10\n",
+			expectError: true,
+		},
+		{
+			name: "explicit zero port not overridden",
+			input: `
+- name: bind9-zero-port
+  address: 192.168.1.10
+  port: 0
+  rndcport: 0
+  rndcsecret: c2VjcmV0
+`,
+			expected: []ExternalBind{
+				{
+					Name:          "bind9-zero-port",
+					Address:       "192.168.1.10",
+					Port:          DNSPort,
+					RndcHost:      nil,
+					RndcKeyName:   DefaultRndcKeyName,
+					RndcAlgorithm: DefaultRndcAlgorithm,
+					RndcSecret:    "c2VjcmV0",
+					RndcPort:      RNDCPort,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ReadExternalBinds([]byte(tc.input))
+
+			if tc.expectError {
+				if err == nil {
+					t.Fatalf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(result) != len(tc.expected) {
+				t.Fatalf("expected %d entries, got %d", len(tc.expected), len(result))
+			}
+
+			for i, got := range result {
+				exp := tc.expected[i]
+				if got.Name != exp.Name {
+					t.Errorf("[%d] Name: got %q, want %q", i, got.Name, exp.Name)
+				}
+				if got.Address != exp.Address {
+					t.Errorf("[%d] Address: got %q, want %q", i, got.Address, exp.Address)
+				}
+				if got.Port != exp.Port {
+					t.Errorf("[%d] Port: got %d, want %d", i, got.Port, exp.Port)
+				}
+				if got.RndcPort != exp.RndcPort {
+					t.Errorf("[%d] RndcPort: got %d, want %d", i, got.RndcPort, exp.RndcPort)
+				}
+				if got.RndcKeyName != exp.RndcKeyName {
+					t.Errorf("[%d] RndcKeyName: got %q, want %q", i, got.RndcKeyName, exp.RndcKeyName)
+				}
+				if got.RndcAlgorithm != exp.RndcAlgorithm {
+					t.Errorf("[%d] RndcAlgorithm: got %q, want %q", i, got.RndcAlgorithm, exp.RndcAlgorithm)
+				}
+				if got.RndcSecret != exp.RndcSecret {
+					t.Errorf("[%d] RndcSecret: got %q, want %q", i, got.RndcSecret, exp.RndcSecret)
+				}
+
+				if (got.RndcHost == nil) != (exp.RndcHost == nil) {
+					t.Errorf("[%d] RndcHost: got %v, want %v", i, got.RndcHost, exp.RndcHost)
+				} else if got.RndcHost != nil && *got.RndcHost != *exp.RndcHost {
+					t.Errorf("[%d] RndcHost: got %q, want %q", i, *got.RndcHost, *exp.RndcHost)
+				}
+			}
+		})
+	}
+}

--- a/internal/designateworker/deployment.go
+++ b/internal/designateworker/deployment.go
@@ -46,17 +46,48 @@ func Deployment(
 	rootUser := int64(0)
 	serviceName := fmt.Sprintf("%s-worker", designate.ServiceName)
 
-	volumeDefs := append(designate.GetStandardVolumeMapping(instance),
-		designate.VolumeMapping{Name: designate.DesignateBindKeySecret, Type: designate.SecretMount, MountPath: "/etc/designate/rndc-keys"})
+	volumes, initVolumeMounts := designate.ProcessVolumes(designate.GetStandardVolumeMapping(instance))
+	projectedVolumes := []corev1.VolumeProjection{
+		{
+			Secret: &corev1.SecretProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: designate.DesignateBindKeySecret,
+				},
+			},
+		},
+		{
+			Secret: &corev1.SecretProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: designate.ExternalRndcData,
+				},
+			},
+		},
+	}
+	var projVolMode int32 = 0640
+	projectedVolume := corev1.Volume{
+		Name: "worker-projected-volumes",
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources:     projectedVolumes,
+				DefaultMode: &projVolMode,
+			},
+		},
+	}
+	volumes = append(volumes, projectedVolume)
 
-	volumes, initVolumeMounts := designate.ProcessVolumes(volumeDefs)
-
-	volumeMounts := append(initVolumeMounts, corev1.VolumeMount{
-		Name:      designate.MergedVolumeName(instance.Name),
-		MountPath: "/var/lib/kolla/config_files/config.json",
-		SubPath:   serviceName + "-config.json",
-		ReadOnly:  true,
-	})
+	volumeMounts := append(initVolumeMounts,
+		corev1.VolumeMount{
+			Name:      designate.MergedVolumeName(instance.Name),
+			MountPath: "/var/lib/kolla/config_files/config.json",
+			SubPath:   serviceName + "-config.json",
+			ReadOnly:  true,
+		},
+		corev1.VolumeMount{
+			Name:      "worker-projected-volumes",
+			MountPath: "/etc/designate/rndc-keys",
+			ReadOnly:  true,
+		},
+	)
 
 	livenessProbe := &corev1.Probe{
 		// TODO might need tuning


### PR DESCRIPTION
Step 1 of supporting external binds is to get the rndc keys in position so bind pool targets will work.