### PR TITLE
Add external dns target data bind pool info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/openstack-k8s-operators/lib-common/modules/openstack v0.6.1-0.20260610101308-d3778a549c89
 	github.com/openstack-k8s-operators/lib-common/modules/test v0.6.1-0.20260610101308-d3778a549c89
 	github.com/openstack-k8s-operators/mariadb-operator/api v0.6.1-0.20260611160416-9d531ed9a9c1
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.31.14
 	k8s.io/apimachinery v0.31.14
@@ -109,6 +108,7 @@ require (
 	google.golang.org/protobuf v1.36.7 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiextensions-apiserver v0.33.2 // indirect
 	k8s.io/apiserver v0.33.2 // indirect
 	k8s.io/component-base v0.33.2 // indirect

--- a/internal/controller/designate_controller.go
+++ b/internal/controller/designate_controller.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -419,20 +419,23 @@ const (
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DesignateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
-	// transportURLSecretFn - Watch for changes made to the secret associated with the RabbitMQ
-	// TransportURL created and used by Designate CRs.  Watch functions return a list of namespace-scoped
-	// CRs that then get fed  to the reconciler.  Hence, in this case, we need to know the name of the
-	// Designate CR associated with the secret we are examining in the function.  We could parse the name
-	// out of the "%s-designate-transport" secret label, which would be faster than getting the list of
-	// the Designate CRs and trying to match on each one.  The downside there, however, is that technically
-	// someone could randomly label a secret "something-designate-transport" where "something" actually
-	// matches the name of an existing Designate CR.  In that case changes to that secret would trigger
-	// reconciliation for a Designate CR that does not need it.
 	//
-	// TODO: We also need a watch func to monitor for changes to the secret referenced by Designate.Spec.Secret
+	// secretWatchFn - Watches for changes to secrets used by Designate CRs. This includes:
+	// - the secret for the RabbitMQ TransportURL owned by a Designate CR, and
+	// - the secret referenced as ExternalBindsSecret in the Designate CR spec.
+	//
+	// Watch functions should return a list of namespace-scoped CRs to reconcile. For TransportURL secrets,
+	// we detect if the secret is owned by a TransportURL resource, and check if the owner name matches a Designate CR.
+	// For ExternalBindsSecret, we check if the secret name is referenced by any Designate CR's Spec.ExternalBindsSecret.
+	//
+	// Note: We could parse the Designate CR name out of the "%s-designate-transport" secret label,
+	// which would be slightly faster than comparing with all Designate CRs, but that risks a false trigger:
+	// a random secret named "something-designate-transport" could match the name of an existing Designate CR,
+	// spuriously triggering reconciliation for a CR that does not own or use that secret.
+	//
 	Log := r.GetLogger(ctx)
 
-	transportURLSecretFn := func(_ context.Context, o client.Object) []reconcile.Request {
+	secretWatchFn := func(ctx context.Context, o client.Object) []reconcile.Request {
 		result := []reconcile.Request{}
 
 		// get all Designate CRs
@@ -440,8 +443,8 @@ func (r *DesignateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		listOpts := []client.ListOption{
 			client.InNamespace(o.GetNamespace()),
 		}
-		if err := r.List(context.Background(), designates, listOpts...); err != nil {
-			Log.Error(err, "Unable to retrieve Designate CRs %v")
+		if err := r.List(ctx, designates, listOpts...); err != nil {
+			Log.Error(err, "Unable to retrieve Designate CRs")
 			return nil
 		}
 
@@ -460,6 +463,16 @@ func (r *DesignateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 				}
 			}
 		}
+
+		for _, cr := range designates.Items {
+			if o.GetName() == cr.Spec.ExternalBindsSecret {
+				name := client.ObjectKey{
+					Namespace: o.GetNamespace(),
+					Name:      cr.Name,
+				}
+				result = append(result, reconcile.Request{NamespacedName: name})
+			}
+		}
 		if len(result) > 0 {
 			return result
 		}
@@ -467,12 +480,12 @@ func (r *DesignateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 	}
 
 	// Watch for changes to the Redis CR used by Designate (e.g. TLS config changes)
-	redisWatchFn := func(_ context.Context, o client.Object) []reconcile.Request {
+	redisWatchFn := func(ctx context.Context, o client.Object) []reconcile.Request {
 		designates := &designatev1beta1.DesignateList{}
 		listOpts := []client.ListOption{
 			client.InNamespace(o.GetNamespace()),
 		}
-		if err := r.List(context.Background(), designates, listOpts...); err != nil {
+		if err := r.List(ctx, designates, listOpts...); err != nil {
 			Log.Error(err, "Unable to retrieve Designate CRs")
 			return nil
 		}
@@ -488,36 +501,6 @@ func (r *DesignateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 			}
 		}
 		return result
-	}
-
-	externalBindsFn := func(_ context.Context, o client.Object) []reconcile.Request {
-		result := []reconcile.Request{}
-
-		var namespace = o.GetNamespace()
-		var secretName = o.GetName()
-
-		designates := &designatev1beta1.DesignateList{}
-		listOpts := []client.ListOption{
-			client.InNamespace(namespace),
-		}
-		if err := r.List(context.Background(), designates, listOpts...); err != nil {
-			Log.Error(err, "Unable to retrieve Designate CRs")
-			return nil
-		}
-
-		for _, cr := range designates.Items {
-			if cr.Spec.ExternalBindsSecret == secretName || secretName == designate.ExternalBindsData {
-				name := client.ObjectKey{
-					Namespace: namespace,
-					Name:      cr.Name,
-				}
-				result = append(result, reconcile.Request{NamespacedName: name})
-			}
-		}
-		if len(result) > 0 {
-			return result
-		}
-		return nil
 	}
 
 	// TODO(beagles):
@@ -546,15 +529,10 @@ func (r *DesignateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 			&corev1.ConfigMap{},
 			handler.EnqueueRequestsFromMapFunc(r.findDesignatesForMultipoolConfigMap),
 		).
+		// Watch for Secrets of interest like TransportURL related or external binds.
 		Watches(
 			&corev1.Secret{},
-			handler.EnqueueRequestsFromMapFunc(externalBindsFn),
-			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
-		).
-		// Watch for TransportURL Secrets which belong to any TransportURLs created by Designate CRs
-		Watches(
-			&corev1.Secret{},
-			handler.EnqueueRequestsFromMapFunc(transportURLSecretFn),
+			handler.EnqueueRequestsFromMapFunc(secretWatchFn),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).
 		// Watch for Redis CR changes (e.g. TLS configuration)
@@ -1016,20 +994,18 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 	}
 	Log.Info("Deployment API task reconciled")
 
-	// Check for external BIND9 configurations.
-	// Note: We can't use getSecret() here as the absence of the secret just means there are
-	// no external binds defined, which is not an error. We need this secret's data
-	// for the pool generator and to create an extra secret for the RNDC keys.
-	// Also note: This is a little problematic with respect to optimization. Any time this
-	// changes we need to:
-	// - rebuild the mountable rndc secret for the workers
-	// - restart the workers ... we should really be starting workers along with mDNS before
-	//   any other designate component.
-	// - regenerate the pools
+	// Handle external BIND9 configurations.
+	// We need the external binds secret data for both the pool generator and to
+	// create an extra secret containing the RNDC keys.
+	//
+	// Note: Any change to this secret requires careful handling:
+	// - Rebuild the mountable RNDC secret for the workers.
+	// - Restart the workers (ideally, workers and mDNS should start before other Designate components).
+	// - Regenerate the pools.
 
 	externalBindData := make(map[string][]designate.ExternalBind)
 	externalRndcSecretData := make(map[string]string)
-	updateRndcSecret := true
+	updateRndcSecret := false
 
 	if instance.Spec.ExternalBindsSecret != "" {
 		externalBindsSecret, hash, err := oko_secret.GetSecret(ctx, helper, instance.Spec.ExternalBindsSecret, instance.Namespace)
@@ -1051,41 +1027,56 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 				err.Error()))
 			return ctrl.Result{}, err
 		}
-
-		if hash != instance.Status.Hash[designate.ExternalBindsData] {
-			// We only care about the data for the default pool at the moment,
-			// but let's accommodate all for the BYOB case in the future.
-			for poolName, data := range externalBindsSecret.Data {
-				externalBinds, err := designate.ReadExternalBinds(data)
-				if err != nil {
-					instance.Status.Conditions.Set(condition.FalseCondition(
-						condition.InputReadyCondition,
-						condition.ErrorReason,
-						condition.SeverityWarning,
-						condition.InputReadyErrorMessage,
-						err.Error()))
-					return ctrl.Result{}, err
-				}
-				externalBindData[poolName] = externalBinds
-				for i, bind := range externalBinds {
-					rndcBlock := fmt.Sprintf(
-						"key \"%s\" {\n\talgorithm %s;\n\tsecret \"%s\";\n};",
-						bind.RndcKeyName, bind.RndcAlgorithm, bind.RndcSecret,
-					)
-					externalRndcSecretData[fmt.Sprintf("%s-rndc-%d", poolName, i)] = rndcBlock
-				}
+		// We only care about the data for the default pool at the moment,
+		// but let's accommodate all for the BYOB case in the future.
+		for poolName, data := range externalBindsSecret.Data {
+			externalBinds, err := designate.ReadExternalBinds(data)
+			if err != nil {
+				instance.Status.Conditions.Set(condition.FalseCondition(
+					condition.InputReadyCondition,
+					condition.ErrorReason,
+					condition.SeverityWarning,
+					condition.InputReadyErrorMessage,
+					err.Error()))
+				return ctrl.Result{}, err
 			}
-			instance.Status.Hash[designate.ExternalBindsData] = hash
-		} else {
-			// if the hash is the same, we don't need to update the rndc secret
-			updateRndcSecret = false
+			externalBindData[poolName] = externalBinds
+			for i, bind := range externalBinds {
+				rndcBlock := fmt.Sprintf("key \"%s\" {\n\talgorithm %s;\n\tsecret \"%s\";\n};",
+					bind.RndcKeyName, bind.RndcAlgorithm, bind.RndcSecret)
+				rndcFilename := fmt.Sprintf("%s-rndc-%d", poolName, i)
+				externalBindData[poolName][i].RndcFile = rndcFilename
+				externalRndcSecretData[rndcFilename] = rndcBlock
+			}
 		}
+		updateRndcSecret = hash != instance.Status.Hash[designate.ExternalBindsData]
+		instance.Status.Hash[designate.ExternalBindsData] = hash
 	} else {
-		instance.Status.Hash[designate.ExternalBindsData] = ""
+		// No external binds secret, so we need to check if the external rndc secret data is present
+		// and if it is - remove the contents so the workers have up to date.
+		_, _, err := oko_secret.GetSecret(ctx, helper, designate.ExternalRndcData, instance.Namespace)
+		// Triggers initial setup if the external rndc secret data is not found.
+		if err != nil {
+			if k8s_errors.IsNotFound(err) {
+				// Initially this is to make sure an empty rndc secret is created because the workers
+				// mount it. This may no longer be true as the workers mount it via projected volumes
+				// and mount the secret as "optional: true", but we'll keep it for now in case there
+				// is some unexpected behaviour there.
+				updateRndcSecret = true
+			} else {
+				return ctrl.Result{}, err
+			}
+		} else if instance.Status.Hash[designate.ExternalBindsData] != "" {
+			updateRndcSecret = true
+			instance.Status.Hash[designate.ExternalBindsData] = ""
+		}
 	}
 
 	if updateRndcSecret {
-		// Update the rndc secret data
+		// Update the rndc secret data - We don't worry about the hash here as this is derived data.
+		// If it's being updated by a change to the ExternalBindsSecret, we update the secret here
+		// and let the controllers for resources that NEED the rndc secret data trigger a reconcile
+		// if needed.
 		labels := labels.GetLabels(instance, labels.GetGroupLabel(instance.Name), map[string]string{})
 		rndcKeySecretData := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1243,7 +1234,7 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 			Data: make(map[string]string),
 		}
 
-		poolsYaml, poolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(updatedBindMap, mdnsConfigMap.Data, nsRecords, multipoolConfig)
+		poolsYaml, poolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(updatedBindMap, mdnsConfigMap.Data, nsRecords, multipoolConfig, externalBindData)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controller/designatebackendbind9_multipool.go
+++ b/internal/controller/designatebackendbind9_multipool.go
@@ -41,7 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	designatev1beta1 "github.com/openstack-k8s-operators/designate-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/designate-operator/internal/designate"
@@ -928,15 +928,15 @@ func (r *DesignateBackendbind9Reconciler) generateTSIGConfig(
 	var config strings.Builder
 
 	// Add key definition
-	config.WriteString(fmt.Sprintf("key \"%s\" {\n", tsigKey.Name))
-	config.WriteString(fmt.Sprintf("    algorithm %s;\n", tsigKey.Algorithm))
-	config.WriteString(fmt.Sprintf("    secret \"%s\";\n", tsigKey.Secret))
+	fmt.Fprintf(&config, "key \"%s\" {\n", tsigKey.Name)
+	fmt.Fprintf(&config, "    algorithm %s;\n", tsigKey.Algorithm)
+	fmt.Fprintf(&config, "    secret \"%s\";\n", tsigKey.Secret)
 	config.WriteString("};\n\n")
 
 	// Add server blocks for each mdns IP
 	for _, mdnsIP := range mdnsIPs {
-		config.WriteString(fmt.Sprintf("server %s {\n", mdnsIP))
-		config.WriteString(fmt.Sprintf("    keys { %s; };\n", tsigKey.Name))
+		fmt.Fprintf(&config, "server %s {\n", mdnsIP)
+		fmt.Fprintf(&config, "    keys { %s; };\n", tsigKey.Name)
 		config.WriteString("};\n")
 	}
 

--- a/internal/controller/designateworker_controller.go
+++ b/internal/controller/designateworker_controller.go
@@ -677,7 +677,6 @@ func (r *DesignateWorkerReconciler) reconcileNormal(ctx context.Context, instanc
 	//
 
 	// Define a new Deployment object
-
 	deplDef := designateworker.Deployment(instance, inputHash, serviceLabels, serviceAnnotations, topology)
 	depl := deployment.NewDeployment(
 		deplDef,
@@ -883,7 +882,7 @@ func (r *DesignateWorkerReconciler) createHashOfInputHashes(
 
 	if err != nil {
 		if k8s_errors.IsNotFound(err) {
-			Log.Error(err, "Unable to retrieve extra rndc key - may not be an error")
+			Log.Info("External RNDC key secret not found, may not be created yet")
 		} else {
 			return "", false, err
 		}

--- a/internal/controller/multipool_configmap_webhook.go
+++ b/internal/controller/multipool_configmap_webhook.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 
 	"github.com/openstack-k8s-operators/designate-operator/internal/designate"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"

--- a/internal/designate/external_binds_reader.go
+++ b/internal/designate/external_binds_reader.go
@@ -16,19 +16,32 @@ limitations under the License.
 package designate
 
 import (
+	"errors"
+	"fmt"
+
 	"gopkg.in/yaml.v3"
+)
+
+var (
+	// ErrExternalBindAddressRequired is returned when an external bind entry omits address.
+	ErrExternalBindAddressRequired = errors.New("address is required for external bind")
+	// ErrExternalBindRndcSecretRequired is returned when an external bind entry omits rndcsecret.
+	ErrExternalBindRndcSecretRequired = errors.New("rndcsecret is required for external bind")
 )
 
 // ExternalBind defines connection parameters for a BIND9 instance not managed by this operator.
 type ExternalBind struct {
-	Name          string  `yaml:"name"`
-	Address       string  `yaml:"address"`
-	Port          int     `yaml:"port"`
-	RndcHost      *string `yaml:"rndchost,omitempty"`
-	RndcKeyName   string  `yaml:"rndckeyname"`
-	RndcAlgorithm string  `yaml:"rndcalgorithm"`
-	RndcSecret    string  `yaml:"rndcsecret"`
-	RndcPort      int     `yaml:"rndcport"`
+	Name          string `yaml:"name"`
+	Address       string `yaml:"address"`
+	Port          int    `yaml:"port"`
+	RndcHost      string `yaml:"rndchost"`
+	RndcKeyName   string `yaml:"rndckeyname"`
+	RndcAlgorithm string `yaml:"rndcalgorithm"`
+	RndcSecret    string `yaml:"rndcsecret"`
+	RndcPort      int    `yaml:"rndcport"`
+	// RndcFile is set by the controller after ReadExternalBinds returns — callers must
+	// populate it before passing ExternalBind to createExternalTargetAndNameserver.
+	RndcFile string `yaml:"-"`
 }
 
 const (
@@ -50,17 +63,29 @@ func ReadExternalBinds(data []byte) ([]ExternalBind, error) {
 	}
 
 	for i := range externalBinds {
+		if externalBinds[i].Address == "" {
+			return nil, fmt.Errorf("%w: %s", ErrExternalBindAddressRequired, externalBinds[i].Name)
+		}
+		if externalBinds[i].RndcSecret == "" {
+			return nil, fmt.Errorf("%w: %s", ErrExternalBindRndcSecretRequired, externalBinds[i].Name)
+		}
 		if externalBinds[i].Port == 0 {
 			externalBinds[i].Port = DNSPort
 		}
 		if externalBinds[i].RndcPort == 0 {
 			externalBinds[i].RndcPort = RNDCPort
 		}
+		if externalBinds[i].RndcHost == "" {
+			externalBinds[i].RndcHost = externalBinds[i].Address
+		}
 		if externalBinds[i].RndcKeyName == "" {
 			externalBinds[i].RndcKeyName = DefaultRndcKeyName
 		}
 		if externalBinds[i].RndcAlgorithm == "" {
 			externalBinds[i].RndcAlgorithm = DefaultRndcAlgorithm
+		}
+		if externalBinds[i].Name == "" {
+			externalBinds[i].Name = fmt.Sprintf("external-bind9-%s", externalBinds[i].Address)
 		}
 	}
 

--- a/internal/designate/external_binds_reader_test.go
+++ b/internal/designate/external_binds_reader_test.go
@@ -42,11 +42,11 @@ func TestReadExternalBinds(t *testing.T) {
   rndcport: 1953
 `,
 			expected: []ExternalBind{
-				{
+				{ //nolint:gosec // G101: test fixture, not a real credential
 					Name:          "bind9-primary",
 					Address:       "192.168.1.10",
 					Port:          5353,
-					RndcHost:      &rndcHost,
+					RndcHost:      rndcHost,
 					RndcKeyName:   "my-custom-key",
 					RndcAlgorithm: "hmac-sha512",
 					RndcSecret:    "c2VjcmV0MTIz",
@@ -62,11 +62,11 @@ func TestReadExternalBinds(t *testing.T) {
   rndcsecret: c2VjcmV0MTIz
 `,
 			expected: []ExternalBind{
-				{
+				{ //nolint:gosec // G101: test fixture, not a real credential
 					Name:          "bind9-minimal",
 					Address:       "192.168.1.10",
 					Port:          DNSPort,
-					RndcHost:      nil,
+					RndcHost:      "192.168.1.10",
 					RndcKeyName:   DefaultRndcKeyName,
 					RndcAlgorithm: DefaultRndcAlgorithm,
 					RndcSecret:    "c2VjcmV0MTIz",
@@ -88,21 +88,21 @@ func TestReadExternalBinds(t *testing.T) {
   rndcsecret: c2VjcmV0Mg==
 `,
 			expected: []ExternalBind{
-				{
+				{ //nolint:gosec // G101: test fixture, not a real credential
 					Name:          "primary",
 					Address:       "192.168.1.10",
 					Port:          5353,
-					RndcHost:      nil,
+					RndcHost:      "192.168.1.10",
 					RndcKeyName:   DefaultRndcKeyName,
 					RndcAlgorithm: DefaultRndcAlgorithm,
 					RndcSecret:    "c2VjcmV0MQ==",
 					RndcPort:      RNDCPort,
 				},
-				{
+				{ //nolint:gosec // G101: test fixture, not a real credential
 					Name:          "secondary",
 					Address:       "192.168.1.11",
 					Port:          DNSPort,
-					RndcHost:      &rndcHost,
+					RndcHost:      rndcHost,
 					RndcKeyName:   "custom-key",
 					RndcAlgorithm: DefaultRndcAlgorithm,
 					RndcSecret:    "c2VjcmV0Mg==",
@@ -131,7 +131,7 @@ func TestReadExternalBinds(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name: "explicit zero port not overridden",
+			name: "zero port treated as default",
 			input: `
 - name: bind9-zero-port
   address: 192.168.1.10
@@ -140,11 +140,11 @@ func TestReadExternalBinds(t *testing.T) {
   rndcsecret: c2VjcmV0
 `,
 			expected: []ExternalBind{
-				{
+				{ //nolint:gosec // G101: test fixture, not a real credential
 					Name:          "bind9-zero-port",
 					Address:       "192.168.1.10",
 					Port:          DNSPort,
-					RndcHost:      nil,
+					RndcHost:      "192.168.1.10",
 					RndcKeyName:   DefaultRndcKeyName,
 					RndcAlgorithm: DefaultRndcAlgorithm,
 					RndcSecret:    "c2VjcmV0",
@@ -197,10 +197,10 @@ func TestReadExternalBinds(t *testing.T) {
 					t.Errorf("[%d] RndcSecret: got %q, want %q", i, got.RndcSecret, exp.RndcSecret)
 				}
 
-				if (got.RndcHost == nil) != (exp.RndcHost == nil) {
-					t.Errorf("[%d] RndcHost: got %v, want %v", i, got.RndcHost, exp.RndcHost)
-				} else if got.RndcHost != nil && *got.RndcHost != *exp.RndcHost {
-					t.Errorf("[%d] RndcHost: got %q, want %q", i, *got.RndcHost, *exp.RndcHost)
+				if (got.RndcHost == "") != (exp.RndcHost == "") {
+					t.Errorf("[%d] RndcHost: got %q, want %q", i, got.RndcHost, exp.RndcHost)
+				} else if got.RndcHost != "" && got.RndcHost != exp.RndcHost {
+					t.Errorf("[%d] RndcHost: got %q, want %q", i, got.RndcHost, exp.RndcHost)
 				}
 			}
 		})

--- a/internal/designate/generate_bind9_pools_yaml.go
+++ b/internal/designate/generate_bind9_pools_yaml.go
@@ -26,7 +26,7 @@ import (
 	"sort"
 	"text/template"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	designatev1 "github.com/openstack-k8s-operators/designate-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
@@ -229,7 +229,7 @@ func validateMultipoolConfig(config *MultipoolConfig, azAwareMode designatev1.De
 }
 
 // GeneratePoolsYamlDataAndHash sorts all pool resources to get the correct hash every time
-func GeneratePoolsYamlDataAndHash(BindMap, MdnsMap map[string]string, nsRecords []designatev1.DesignateNSRecord, multipoolConfig *MultipoolConfig) (string, string, error) {
+func GeneratePoolsYamlDataAndHash(BindMap, MdnsMap map[string]string, nsRecords []designatev1.DesignateNSRecord, multipoolConfig *MultipoolConfig, externalBinds map[string][]ExternalBind) (string, string, error) {
 	masterHosts := make([]string, 0, len(MdnsMap))
 	for _, host := range MdnsMap {
 		masterHosts = append(masterHosts, host)
@@ -239,7 +239,7 @@ func GeneratePoolsYamlDataAndHash(BindMap, MdnsMap map[string]string, nsRecords 
 	var pools []Pool
 
 	if multipoolConfig == nil {
-		pool, err := generateDefaultPool(BindMap, masterHosts, nsRecords)
+		pool, err := generateDefaultPool(BindMap, masterHosts, nsRecords, externalBinds["default"])
 		if err != nil {
 			return "", "", err
 		}
@@ -328,7 +328,27 @@ func createTargetAndNameserver(bindIP string, globalIndex int, masters []Master,
 	return target, nameserver
 }
 
-func generateDefaultPool(BindMap map[string]string, masterHosts []string, nsRecords []designatev1.DesignateNSRecord) (Pool, error) {
+func createExternalTargetAndNameserver(bindInfo ExternalBind, masters []Master, description string) (Target, Nameserver) {
+	nameserver := Nameserver{
+		Host: bindInfo.Address,
+		Port: bindInfo.Port,
+	}
+	target := Target{
+		Type:        "bind9",
+		Description: description,
+		Masters:     masters,
+		Options: Options{
+			Host:        bindInfo.Address,
+			Port:        bindInfo.Port,
+			RNDCHost:    bindInfo.RndcHost,
+			RNDCPort:    bindInfo.RndcPort,
+			RNDCKeyFile: fmt.Sprintf("%s/%s", RndcConfDir, bindInfo.RndcFile),
+		},
+	}
+	return target, nameserver
+}
+
+func generateDefaultPool(BindMap map[string]string, masterHosts []string, nsRecords []designatev1.DesignateNSRecord, externalBinds []ExternalBind) (Pool, error) {
 	sortNSRecords(nsRecords)
 
 	bindIPs := make([]string, len(BindMap))
@@ -343,6 +363,18 @@ func generateDefaultPool(BindMap map[string]string, masterHosts []string, nsReco
 		description := fmt.Sprintf("BIND9 Server %d (%s)", i, bindIPs[i])
 		targets[i], nameservers[i] = createTargetAndNameserver(bindIPs[i], i, masters, description, "", "")
 	}
+
+	// NOTE: external BIND9 servers inherit the internal mDNS masters list. These masters may not be
+	// reachable from an external network — the deployer must ensure connectivity (e.g. via NAT, an
+	// exposed mDNS endpoint, or custom master addresses in a future iteration of this feature).
+	externalTargets := make([]Target, len(externalBinds))
+	externalNameservers := make([]Nameserver, len(externalBinds))
+	for i := range externalBinds {
+		description := fmt.Sprintf("External BIND9 Server %d (%s)", i, externalBinds[i].Name)
+		externalTargets[i], externalNameservers[i] = createExternalTargetAndNameserver(externalBinds[i], masters, description)
+	}
+	targets = append(targets, externalTargets...)
+	nameservers = append(nameservers, externalNameservers...)
 
 	// Catalog zone is an optional section
 	// catalogZone := &CatalogZone{

--- a/internal/designate/generate_bind9_pools_yaml_test.go
+++ b/internal/designate/generate_bind9_pools_yaml_test.go
@@ -283,7 +283,7 @@ func TestGenerateDefaultPool(t *testing.T) {
 		{Hostname: "ns2.example.org.", Priority: 2},
 	}
 
-	pool, err := generateDefaultPool(bindMap, masterHosts, nsRecords)
+	pool, err := generateDefaultPool(bindMap, masterHosts, nsRecords, []ExternalBind{})
 	if err != nil {
 		t.Fatalf("generateDefaultPool() error = %v", err)
 	}
@@ -457,7 +457,7 @@ func TestSinglePoolModeUsesCRNSRecords(t *testing.T) {
 	}
 
 	// In single-pool mode, generateDefaultPool should use CR NS records
-	pool, err := generateDefaultPool(bindMap, masterHosts, crNSRecords)
+	pool, err := generateDefaultPool(bindMap, masterHosts, crNSRecords, []ExternalBind{})
 	if err != nil {
 		t.Fatalf("generateDefaultPool() error = %v", err)
 	}
@@ -476,5 +476,283 @@ func TestSinglePoolModeUsesCRNSRecords(t *testing.T) {
 
 	if pool.NSRecords[1].Hostname != "ns2-cr-single.example.org." {
 		t.Errorf("expected single-pool mode to use CR NS record 'ns2-cr-single.example.org.', got %s", pool.NSRecords[1].Hostname)
+	}
+}
+
+func TestCreateExternalTargetAndNameserver(t *testing.T) {
+	masters := []Master{{Host: "192.168.1.20", Port: MdnsMasterPort}}
+
+	tests := []struct {
+		name            string
+		bindInfo        ExternalBind
+		description     string
+		wantHost        string
+		wantPort        int
+		wantRndcHost    string
+		wantRndcPort    int
+		wantRndcKeyFile string
+	}{
+		{
+			name: "minimal external bind with defaults",
+			bindInfo: ExternalBind{
+				Name:     "bind9-external",
+				Address:  "192.168.100.50",
+				Port:     DNSPort,
+				RndcHost: "192.168.100.50",
+				RndcPort: RNDCPort,
+				RndcFile: "default-rndc-0",
+			},
+			description:     "External BIND9 Server 0 (bind9-external)",
+			wantHost:        "192.168.100.50",
+			wantPort:        DNSPort,
+			wantRndcHost:    "192.168.100.50",
+			wantRndcPort:    RNDCPort,
+			wantRndcKeyFile: "/etc/designate/rndc-keys/default-rndc-0",
+		},
+		{
+			name: "custom ports and separate rndc host",
+			bindInfo: ExternalBind{
+				Name:     "bind9-primary",
+				Address:  "192.168.1.10",
+				Port:     5353,
+				RndcHost: "10.0.0.99",
+				RndcPort: 1953,
+				RndcFile: "default-rndc-1",
+			},
+			description:     "External BIND9 Server 1 (bind9-primary)",
+			wantHost:        "192.168.1.10",
+			wantPort:        5353,
+			wantRndcHost:    "10.0.0.99",
+			wantRndcPort:    1953,
+			wantRndcKeyFile: "/etc/designate/rndc-keys/default-rndc-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target, nameserver := createExternalTargetAndNameserver(tt.bindInfo, masters, tt.description)
+
+			if target.Type != "bind9" {
+				t.Errorf("expected target type 'bind9', got %s", target.Type)
+			}
+			if target.Description != tt.description {
+				t.Errorf("expected description %q, got %q", tt.description, target.Description)
+			}
+			if target.TSIGKeyID != "" {
+				t.Errorf("expected empty TSIGKeyID for external target, got %q", target.TSIGKeyID)
+			}
+			if len(target.Masters) != 1 {
+				t.Fatalf("expected 1 master, got %d", len(target.Masters))
+			}
+			if target.Masters[0].Host != "192.168.1.20" {
+				t.Errorf("expected master host '192.168.1.20', got %s", target.Masters[0].Host)
+			}
+			if target.Masters[0].Port != MdnsMasterPort {
+				t.Errorf("expected master port %d, got %d", MdnsMasterPort, target.Masters[0].Port)
+			}
+			if target.Options.Host != tt.wantHost {
+				t.Errorf("expected options host %q, got %q", tt.wantHost, target.Options.Host)
+			}
+			if target.Options.Port != tt.wantPort {
+				t.Errorf("expected options port %d, got %d", tt.wantPort, target.Options.Port)
+			}
+			if target.Options.RNDCHost != tt.wantRndcHost {
+				t.Errorf("expected RNDC host %q, got %q", tt.wantRndcHost, target.Options.RNDCHost)
+			}
+			if target.Options.RNDCPort != tt.wantRndcPort {
+				t.Errorf("expected RNDC port %d, got %d", tt.wantRndcPort, target.Options.RNDCPort)
+			}
+			if target.Options.RNDCKeyFile != tt.wantRndcKeyFile {
+				t.Errorf("expected RNDC key file %q, got %q", tt.wantRndcKeyFile, target.Options.RNDCKeyFile)
+			}
+			if target.Options.View != "" {
+				t.Errorf("expected empty view for external target, got %q", target.Options.View)
+			}
+
+			if nameserver.Host != tt.wantHost {
+				t.Errorf("expected nameserver host %q, got %q", tt.wantHost, nameserver.Host)
+			}
+			if nameserver.Port != tt.wantPort {
+				t.Errorf("expected nameserver port %d, got %d", tt.wantPort, nameserver.Port)
+			}
+			if nameserver.TSIGKeyID != "" {
+				t.Errorf("expected empty TSIGKeyID for external nameserver, got %q", nameserver.TSIGKeyID)
+			}
+		})
+	}
+}
+
+func TestGenerateDefaultPoolWithExternalBinds(t *testing.T) {
+	bindMap := map[string]string{
+		"bind_address_0": "192.168.1.10",
+		"bind_address_1": "192.168.1.11",
+	}
+	masterHosts := []string{"192.168.1.20", "192.168.1.21"}
+	nsRecords := []designatev1.DesignateNSRecord{
+		{Hostname: "ns1.example.org.", Priority: 1},
+	}
+	externalBinds := []ExternalBind{
+		{
+			Name:     "bind9-external",
+			Address:  "192.168.100.50",
+			Port:     DNSPort,
+			RndcHost: "192.168.100.50",
+			RndcPort: RNDCPort,
+			RndcFile: "default-rndc-0",
+		},
+	}
+
+	pool, err := generateDefaultPool(bindMap, masterHosts, nsRecords, externalBinds)
+	if err != nil {
+		t.Fatalf("generateDefaultPool() error = %v", err)
+	}
+
+	if len(pool.Targets) != 3 {
+		t.Fatalf("expected 3 targets (2 internal + 1 external), got %d", len(pool.Targets))
+	}
+	if len(pool.Nameservers) != 3 {
+		t.Fatalf("expected 3 nameservers (2 internal + 1 external), got %d", len(pool.Nameservers))
+	}
+
+	internalTarget := pool.Targets[0]
+	if internalTarget.Options.Host != "192.168.1.10" {
+		t.Errorf("expected first internal target host '192.168.1.10', got %s", internalTarget.Options.Host)
+	}
+	if internalTarget.Options.RNDCKeyFile != "/etc/designate/rndc-keys/rndc-key-0" {
+		t.Errorf("expected internal RNDC key file '/etc/designate/rndc-keys/rndc-key-0', got %s", internalTarget.Options.RNDCKeyFile)
+	}
+
+	externalTarget := pool.Targets[2]
+	if externalTarget.Description != "External BIND9 Server 0 (bind9-external)" {
+		t.Errorf("expected external target description 'External BIND9 Server 0 (bind9-external)', got %s", externalTarget.Description)
+	}
+	if externalTarget.Options.Host != "192.168.100.50" {
+		t.Errorf("expected external target host '192.168.100.50', got %s", externalTarget.Options.Host)
+	}
+	if externalTarget.Options.RNDCHost != "192.168.100.50" {
+		t.Errorf("expected external RNDC host '192.168.100.50', got %s", externalTarget.Options.RNDCHost)
+	}
+	if externalTarget.Options.RNDCKeyFile != "/etc/designate/rndc-keys/default-rndc-0" {
+		t.Errorf("expected external RNDC key file '/etc/designate/rndc-keys/default-rndc-0', got %s", externalTarget.Options.RNDCKeyFile)
+	}
+	if len(externalTarget.Masters) != 2 {
+		t.Errorf("expected 2 masters on external target, got %d", len(externalTarget.Masters))
+	}
+
+	externalNameserver := pool.Nameservers[2]
+	if externalNameserver.Host != "192.168.100.50" {
+		t.Errorf("expected external nameserver host '192.168.100.50', got %s", externalNameserver.Host)
+	}
+	if externalNameserver.Port != DNSPort {
+		t.Errorf("expected external nameserver port %d, got %d", DNSPort, externalNameserver.Port)
+	}
+}
+
+func TestGenerateDefaultPoolWithMultipleExternalBinds(t *testing.T) {
+	bindMap := map[string]string{
+		"bind_address_0": "192.168.1.10",
+	}
+	masterHosts := []string{"192.168.1.20"}
+	nsRecords := []designatev1.DesignateNSRecord{
+		{Hostname: "ns1.example.org.", Priority: 1},
+	}
+	externalBinds := []ExternalBind{
+		{
+			Name:     "bind9-external-1",
+			Address:  "192.168.100.50",
+			Port:     DNSPort,
+			RndcHost: "192.168.100.50",
+			RndcPort: RNDCPort,
+			RndcFile: "default-rndc-0",
+		},
+		{
+			Name:     "bind9-external-2",
+			Address:  "192.168.100.51",
+			Port:     5353,
+			RndcHost: "10.0.0.99",
+			RndcPort: 1953,
+			RndcFile: "default-rndc-1",
+		},
+	}
+
+	pool, err := generateDefaultPool(bindMap, masterHosts, nsRecords, externalBinds)
+	if err != nil {
+		t.Fatalf("generateDefaultPool() error = %v", err)
+	}
+
+	if len(pool.Targets) != 3 {
+		t.Fatalf("expected 3 targets (1 internal + 2 external), got %d", len(pool.Targets))
+	}
+
+	firstExternal := pool.Targets[1]
+	if firstExternal.Description != "External BIND9 Server 0 (bind9-external-1)" {
+		t.Errorf("expected first external description 'External BIND9 Server 0 (bind9-external-1)', got %s", firstExternal.Description)
+	}
+	if firstExternal.Options.Host != "192.168.100.50" {
+		t.Errorf("expected first external host '192.168.100.50', got %s", firstExternal.Options.Host)
+	}
+
+	secondExternal := pool.Targets[2]
+	if secondExternal.Description != "External BIND9 Server 1 (bind9-external-2)" {
+		t.Errorf("expected second external description 'External BIND9 Server 1 (bind9-external-2)', got %s", secondExternal.Description)
+	}
+	if secondExternal.Options.Host != "192.168.100.51" {
+		t.Errorf("expected second external host '192.168.100.51', got %s", secondExternal.Options.Host)
+	}
+	if secondExternal.Options.Port != 5353 {
+		t.Errorf("expected second external port 5353, got %d", secondExternal.Options.Port)
+	}
+	if secondExternal.Options.RNDCHost != "10.0.0.99" {
+		t.Errorf("expected second external RNDC host '10.0.0.99', got %s", secondExternal.Options.RNDCHost)
+	}
+	if secondExternal.Options.RNDCPort != 1953 {
+		t.Errorf("expected second external RNDC port 1953, got %d", secondExternal.Options.RNDCPort)
+	}
+	if secondExternal.Options.RNDCKeyFile != "/etc/designate/rndc-keys/default-rndc-1" {
+		t.Errorf("expected second external RNDC key file '/etc/designate/rndc-keys/default-rndc-1', got %s", secondExternal.Options.RNDCKeyFile)
+	}
+}
+
+func TestGenerateDefaultPoolWithExternalBindsFromYAML(t *testing.T) {
+	bindMap := map[string]string{
+		"bind_address_0": "192.168.1.10",
+	}
+	masterHosts := []string{"192.168.1.20"}
+	nsRecords := []designatev1.DesignateNSRecord{
+		{Hostname: "ns1.example.org.", Priority: 1},
+	}
+
+	externalBindsYAML := `
+- name: bind9-external
+  address: 192.168.100.50
+  rndcsecret: c2VjcmV0MTIz
+`
+	parsedBinds, err := ReadExternalBinds([]byte(externalBindsYAML))
+	if err != nil {
+		t.Fatalf("ReadExternalBinds() error = %v", err)
+	}
+	parsedBinds[0].RndcFile = "default-rndc-0"
+
+	pool, err := generateDefaultPool(bindMap, masterHosts, nsRecords, parsedBinds)
+	if err != nil {
+		t.Fatalf("generateDefaultPool() error = %v", err)
+	}
+
+	if len(pool.Targets) != 2 {
+		t.Fatalf("expected 2 targets (1 internal + 1 external), got %d", len(pool.Targets))
+	}
+
+	externalTarget := pool.Targets[1]
+	if externalTarget.Options.Host != "192.168.100.50" {
+		t.Errorf("expected external target host '192.168.100.50', got %s", externalTarget.Options.Host)
+	}
+	if externalTarget.Options.Port != DNSPort {
+		t.Errorf("expected external target port %d, got %d", DNSPort, externalTarget.Options.Port)
+	}
+	if externalTarget.Options.RNDCHost != "192.168.100.50" {
+		t.Errorf("expected external RNDC host defaulted to address, got %s", externalTarget.Options.RNDCHost)
+	}
+	if externalTarget.Options.RNDCPort != RNDCPort {
+		t.Errorf("expected external RNDC port %d, got %d", RNDCPort, externalTarget.Options.RNDCPort)
 	}
 }

--- a/internal/designateworker/deployment.go
+++ b/internal/designateworker/deployment.go
@@ -28,6 +28,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -60,6 +61,10 @@ func Deployment(
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: designate.ExternalRndcData,
 				},
+				// While the operator should ensure that this secret is always present,
+				// hedge our bets in case something happens where the deployment spec somehow
+				// takes affect before the rndc secret is available.
+				Optional: ptr.To(true),
 			},
 		},
 	}

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -45,6 +45,13 @@ const (
 	KeystoneSecretName = "%s-keystone-secret" // #nosec G101
 	RabbitmqSecretName = "rabbitmq-secret"
 
+	// Test fixture secret name only; not a real credential.
+	ExternalBindsSecretTestName = "designate-external-binds-test" // #nosec G101
+	ExternalBindAddress         = "192.168.100.50"
+	ExternalBindName            = "bind9-external"
+	// Fake RNDC secret for functional tests only; not a real credential.
+	ExternalRndcSecretValue = "c2VjcmV0MTIz" // #nosec G101
+
 	PublicCertSecretName   = "public-tls-certs"   // #nosec G101
 	InternalCertSecretName = "internal-tls-certs" // #nosec G101
 	CABundleSecretName     = "combined-ca-bundle" // #nosec G101
@@ -616,6 +623,19 @@ func CreateNode(name types.NamespacedName) client.Object {
 		"spec": map[string]any{},
 	}
 	return th.CreateUnstructured(raw)
+}
+
+func CreateExternalBindsSecret(name types.NamespacedName) *corev1.Secret {
+	bindsYAML := fmt.Sprintf("- name: %s\n  address: %s\n  rndcsecret: %s\n",
+		ExternalBindName, ExternalBindAddress, ExternalRndcSecretValue)
+	return th.CreateSecret(name, map[string][]byte{
+		designate.DefaultPoolName: []byte(bindsYAML),
+	})
+}
+
+func createAndSimulateExternalBinds(secretName types.NamespacedName) {
+	secret := CreateExternalBindsSecret(secretName)
+	DeferCleanup(k8sClient.Delete, ctx, secret)
 }
 
 func CreateDesignateNSRecordsConfigMap(name types.NamespacedName) client.Object {

--- a/test/functional/designate_controller_test.go
+++ b/test/functional/designate_controller_test.go
@@ -22,13 +22,14 @@ import (
 	"net"
 	"regexp"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
 	. "github.com/onsi/gomega"    //revive:disable:dot-imports
 	"k8s.io/apimachinery/pkg/types"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -830,15 +831,279 @@ var _ = Describe("Designate controller", func() {
 				allNSRecords = append(allNSRecords, nsRecords...)
 			}
 
-			_, poolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, allNSRecords, nil)
+			_, poolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, allNSRecords, nil, make(map[string][]designate.ExternalBind))
 			Expect(err).ToNot(HaveOccurred())
 
 			// we used to have inconsistent ordering, so generate the pools.yaml 10 times and make sure it is has exactly the same content
 			for range 10 {
-				_, newPoolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, allNSRecords, nil)
+				_, newPoolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, allNSRecords, nil, make(map[string][]designate.ExternalBind))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(poolsYamlHash).Should(Equal(newPoolsYamlHash))
 			}
+		})
+
+		It("should create an empty designate-external-rndc secret", func() {
+			Eventually(func(g Gomega) {
+				secret := th.GetSecret(types.NamespacedName{
+					Name:      designate.ExternalRndcData,
+					Namespace: namespace,
+				})
+				g.Expect(secret).ToNot(BeNil())
+				g.Expect(secret.Data).To(BeEmpty())
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	When("Designate is configured with external BIND9 servers", func() {
+		var externalBindsSecretName types.NamespacedName
+
+		BeforeEach(func() {
+			externalBindsSecretName = types.NamespacedName{
+				Namespace: namespace,
+				Name:      ExternalBindsSecretTestName,
+			}
+			spec["externalBindsSecret"] = ExternalBindsSecretTestName
+
+			createAndSimulateKeystone(designateName)
+			createAndSimulateRedis(designateRedisName)
+			createAndSimulateDesignateSecrets(designateName)
+			createAndSimulateTransportURL(transportURLName, transportURLSecretName)
+			createAndSimulateDB(spec)
+			createAndSimulateExternalBinds(externalBindsSecretName)
+
+			DeferCleanup(k8sClient.Delete, ctx, CreateNAD(types.NamespacedName{
+				Name:      spec["designateNetworkAttachment"].(string),
+				Namespace: namespace,
+			}))
+			DeferCleanup(th.DeleteInstance, CreateDesignate(designateName, spec))
+			th.SimulateJobSuccess(designateDBSyncName)
+
+			createAndSimulateBind9(designateBind9Name)
+			createAndSimulateMdns(designateMdnsName)
+			createAndSimulateNSRecordsConfigMap(designateNSRecordConfigMapName)
+			simulateCentralReadyCount(designateName, 1)
+		})
+
+		It("creates designate-external-rndc secret with RNDC key blocks", func() {
+			Eventually(func(g Gomega) {
+				secret := th.GetSecret(types.NamespacedName{
+					Name:      designate.ExternalRndcData,
+					Namespace: namespace,
+				})
+				g.Expect(secret).ToNot(BeNil())
+				g.Expect(secret.Data).To(HaveKey("default-rndc-0"))
+
+				rndcBlock := string(secret.Data["default-rndc-0"])
+				g.Expect(rndcBlock).To(ContainSubstring(`key "rndc-key"`))
+				g.Expect(rndcBlock).To(ContainSubstring("algorithm hmac-sha256"))
+				g.Expect(rndcBlock).To(ContainSubstring(fmt.Sprintf(`secret "%s"`, ExternalRndcSecretValue)))
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("records external binds secret hash in status", func() {
+			Eventually(func(g Gomega) {
+				designateCR := GetDesignate(designateName)
+				g.Expect(designateCR.Status.Hash[designate.ExternalBindsData]).ToNot(BeEmpty())
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("includes external BIND9 targets in pools.yaml", func() {
+			Eventually(func(g Gomega) {
+				poolsYamlConfigMap := th.GetConfigMap(types.NamespacedName{
+					Name:      designate.PoolsYamlConfigMap,
+					Namespace: namespace,
+				})
+				g.Expect(poolsYamlConfigMap).ToNot(BeNil())
+
+				var pools []designate.Pool
+				err := yaml.Unmarshal([]byte(poolsYamlConfigMap.Data[designate.PoolsYamlContent]), &pools)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(pools).To(HaveLen(1))
+
+				pool := pools[0]
+				g.Expect(pool.Targets).To(HaveLen(bind9ReplicaCount + 1))
+				g.Expect(pool.Nameservers).To(HaveLen(bind9ReplicaCount + 1))
+
+				externalTarget := pool.Targets[len(pool.Targets)-1]
+				g.Expect(externalTarget.Type).To(Equal("bind9"))
+				g.Expect(externalTarget.Description).To(Equal(
+					fmt.Sprintf("External BIND9 Server 0 (%s)", ExternalBindName)))
+				g.Expect(externalTarget.Options.Host).To(Equal(ExternalBindAddress))
+				g.Expect(externalTarget.Options.RNDCHost).To(Equal(ExternalBindAddress))
+				g.Expect(externalTarget.Options.Port).To(Equal(53))
+				g.Expect(externalTarget.Options.RNDCPort).To(Equal(953))
+				g.Expect(externalTarget.Options.RNDCKeyFile).To(Equal(
+					fmt.Sprintf("%s/default-rndc-0", designate.RndcConfDir)))
+
+				externalNameserver := pool.Nameservers[len(pool.Nameservers)-1]
+				g.Expect(externalNameserver.Host).To(Equal(ExternalBindAddress))
+				g.Expect(externalNameserver.Port).To(Equal(53))
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("mounts external RNDC keys in worker deployment", func() {
+			workerDeploymentName := types.NamespacedName{
+				Namespace: namespace,
+				Name:      fmt.Sprintf("%s-worker", designateName.Name),
+			}
+
+			Eventually(func(g Gomega) {
+				deployment := &appsv1.Deployment{}
+				g.Expect(k8sClient.Get(ctx, workerDeploymentName, deployment)).Should(Succeed())
+
+				var projectedVolume *corev1.Volume
+				for i := range deployment.Spec.Template.Spec.Volumes {
+					if deployment.Spec.Template.Spec.Volumes[i].Name == "worker-projected-volumes" {
+						projectedVolume = &deployment.Spec.Template.Spec.Volumes[i]
+						break
+					}
+				}
+				g.Expect(projectedVolume).ToNot(BeNil())
+
+				foundExternalRndc := false
+				for _, source := range projectedVolume.VolumeSource.Projected.Sources {
+					if source.Secret != nil && source.Secret.Name == designate.ExternalRndcData {
+						foundExternalRndc = true
+						g.Expect(source.Secret.Optional).ToNot(BeNil())
+						g.Expect(*source.Secret.Optional).To(BeTrue())
+					}
+				}
+				g.Expect(foundExternalRndc).To(BeTrue())
+
+				var rndcMount *corev1.VolumeMount
+				for i := range deployment.Spec.Template.Spec.Containers[0].VolumeMounts {
+					if deployment.Spec.Template.Spec.Containers[0].VolumeMounts[i].Name == "worker-projected-volumes" {
+						rndcMount = &deployment.Spec.Template.Spec.Containers[0].VolumeMounts[i]
+						break
+					}
+				}
+				g.Expect(rndcMount).ToNot(BeNil())
+				g.Expect(rndcMount.MountPath).To(Equal(designate.RndcConfDir))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	When("external binds secret is not found", func() {
+		BeforeEach(func() {
+			spec["externalBindsSecret"] = "nonexistent-external-binds-secret"
+
+			createAndSimulateKeystone(designateName)
+			createAndSimulateRedis(designateRedisName)
+			createAndSimulateDesignateSecrets(designateName)
+			createAndSimulateTransportURL(transportURLName, transportURLSecretName)
+			createAndSimulateDB(spec)
+
+			DeferCleanup(k8sClient.Delete, ctx, CreateNAD(types.NamespacedName{
+				Name:      spec["designateNetworkAttachment"].(string),
+				Namespace: namespace,
+			}))
+			DeferCleanup(th.DeleteInstance, CreateDesignate(designateName, spec))
+			th.SimulateJobSuccess(designateDBSyncName)
+		})
+
+		It("should set InputReady condition to False", func() {
+			Eventually(func(g Gomega) {
+				designateCR := GetDesignate(designateName)
+				cond := designateCR.Status.Conditions.Get(condition.InputReadyCondition)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(cond.Message).To(ContainSubstring("External Binds Secret nonexistent-external-binds-secret not found"))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	When("external binds secret is removed from spec", func() {
+		var externalBindsSecretName types.NamespacedName
+
+		BeforeEach(func() {
+			externalBindsSecretName = types.NamespacedName{
+				Namespace: namespace,
+				Name:      ExternalBindsSecretTestName,
+			}
+			spec["externalBindsSecret"] = ExternalBindsSecretTestName
+
+			createAndSimulateKeystone(designateName)
+			createAndSimulateRedis(designateRedisName)
+			createAndSimulateDesignateSecrets(designateName)
+			createAndSimulateTransportURL(transportURLName, transportURLSecretName)
+			createAndSimulateDB(spec)
+			createAndSimulateExternalBinds(externalBindsSecretName)
+
+			DeferCleanup(k8sClient.Delete, ctx, CreateNAD(types.NamespacedName{
+				Name:      spec["designateNetworkAttachment"].(string),
+				Namespace: namespace,
+			}))
+			DeferCleanup(th.DeleteInstance, CreateDesignate(designateName, spec))
+			th.SimulateJobSuccess(designateDBSyncName)
+
+			createAndSimulateBind9(designateBind9Name)
+			createAndSimulateMdns(designateMdnsName)
+			createAndSimulateNSRecordsConfigMap(designateNSRecordConfigMapName)
+			simulateCentralReadyCount(designateName, 1)
+		})
+
+		It("clears external BIND9 targets from pools.yaml", func() {
+			Eventually(func(g Gomega) {
+				poolsYamlConfigMap := th.GetConfigMap(types.NamespacedName{
+					Name:      designate.PoolsYamlConfigMap,
+					Namespace: namespace,
+				})
+				var pools []designate.Pool
+				err := yaml.Unmarshal([]byte(poolsYamlConfigMap.Data[designate.PoolsYamlContent]), &pools)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(pools[0].Targets).To(HaveLen(bind9ReplicaCount + 1))
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				designateCR := GetDesignate(designateName)
+				designateCR.Spec.ExternalBindsSecret = ""
+				g.Expect(k8sClient.Update(ctx, designateCR)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			simulateCentralReadyCount(designateName, 1)
+
+			Eventually(func(g Gomega) {
+				poolsYamlConfigMap := th.GetConfigMap(types.NamespacedName{
+					Name:      designate.PoolsYamlConfigMap,
+					Namespace: namespace,
+				})
+				var pools []designate.Pool
+				err := yaml.Unmarshal([]byte(poolsYamlConfigMap.Data[designate.PoolsYamlContent]), &pools)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(pools[0].Targets).To(HaveLen(bind9ReplicaCount))
+				g.Expect(pools[0].Nameservers).To(HaveLen(bind9ReplicaCount))
+
+				for _, target := range pools[0].Targets {
+					g.Expect(target.Description).ToNot(ContainSubstring("External BIND9 Server"))
+				}
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("clears designate-external-rndc secret data", func() {
+			Eventually(func(g Gomega) {
+				secret := th.GetSecret(types.NamespacedName{
+					Name:      designate.ExternalRndcData,
+					Namespace: namespace,
+				})
+				g.Expect(secret.Data).To(HaveKey("default-rndc-0"))
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				designateCR := GetDesignate(designateName)
+				designateCR.Spec.ExternalBindsSecret = ""
+				g.Expect(k8sClient.Update(ctx, designateCR)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				secret := th.GetSecret(types.NamespacedName{
+					Name:      designate.ExternalRndcData,
+					Namespace: namespace,
+				})
+				g.Expect(secret.Data).To(BeEmpty())
+
+				designateCR := GetDesignate(designateName)
+				g.Expect(designateCR.Status.Hash[designate.ExternalBindsData]).To(BeEmpty())
+			}, timeout, interval).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
Using a user provided secret as source data, add definitions for external bind9 servers to the pool generation.

(currently wip waiting on merge of "Support external bind information (mounting rndc keys only)" commit in a separate PR)