### PR TITLE
Add AZ-aware mode CR field and extend ConfigMap validation

### DIFF
--- a/api/bases/designate.openstack.org_designates.yaml
+++ b/api/bases/designate.openstack.org_designates.yaml
@@ -52,6 +52,16 @@ spec:
                 default: 120
                 description: Designate API timeout
                 type: integer
+              azAwareMode:
+                description: |-
+                  AZAwareMode - when set to "Enabled", activates AZ-aware multipool mode with
+                  BIND views, per-pool TSIG keys, and per-AZ Unbound instances. Requires a valid
+                  multipool ConfigMap with view fields defined for each pool.
+                enum:
+                - ""
+                - Enabled
+                - Disabled
+                type: string
               backendMdnsServerProtocol:
                 description: |-
                   BackendTypeProtocol - Defines the backend protocol to be used between the designate-worker &

--- a/api/v1beta1/designate_types.go
+++ b/api/v1beta1/designate_types.go
@@ -26,7 +26,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// DesignateAZMode describes the AZ-aware multipool mode setting
+// +kubebuilder:validation:Enum="";Enabled;Disabled
+type DesignateAZMode string
+
 const (
+	// AZModeEnabled activates AZ-aware multipool with BIND views and per-pool TSIG keys
+	AZModeEnabled DesignateAZMode = "Enabled"
+
+	// AZModeDisabled explicitly disables AZ-aware multipool mode
+	AZModeDisabled DesignateAZMode = "Disabled"
+
 	// DbSyncHash hash
 	DbSyncHash = "dbsync"
 
@@ -235,6 +245,12 @@ type DesignateSpecBase struct {
 	// +kubebuilder:validation:Optional
 	// ExternalBindsSecret is the name of the secret containing external BIND9 configurations
 	ExternalBindsSecret string `json:"externalBindsSecret,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	// AZAwareMode - when set to "Enabled", activates AZ-aware multipool mode with
+	// BIND views, per-pool TSIG keys, and per-AZ Unbound instances. Requires a valid
+	// multipool ConfigMap with view fields defined for each pool.
+	AZAwareMode DesignateAZMode `json:"azAwareMode,omitempty"`
 }
 
 // DesignateStatus defines the observed state of Designate

--- a/config/crd/bases/designate.openstack.org_designates.yaml
+++ b/config/crd/bases/designate.openstack.org_designates.yaml
@@ -52,6 +52,16 @@ spec:
                 default: 120
                 description: Designate API timeout
                 type: integer
+              azAwareMode:
+                description: |-
+                  AZAwareMode - when set to "Enabled", activates AZ-aware multipool mode with
+                  BIND views, per-pool TSIG keys, and per-AZ Unbound instances. Requires a valid
+                  multipool ConfigMap with view fields defined for each pool.
+                enum:
+                - ""
+                - Enabled
+                - Disabled
+                type: string
               backendMdnsServerProtocol:
                 description: |-
                   BackendTypeProtocol - Defines the backend protocol to be used between the designate-worker &

--- a/internal/controller/designate_controller.go
+++ b/internal/controller/designate_controller.go
@@ -1108,7 +1108,7 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 	}
 
 	// Get multipool configuration once for use in bind IP allocation and pools.yaml generation
-	multipoolConfig, err := designate.GetMultipoolConfig(ctx, helper.GetClient(), instance.Namespace)
+	multipoolConfig, err := designate.GetMultipoolConfig(ctx, helper.GetClient(), instance.Namespace, instance.Spec.AZAwareMode)
 	if err != nil {
 		Log.Error(err, "Failed to get multipool configuration")
 		return ctrl.Result{}, err
@@ -1690,7 +1690,7 @@ func (r *DesignateReconciler) generateServiceConfigMaps(
 	cmLabels := labels.GetLabels(instance, labels.GetGroupLabel(designate.ServiceName), map[string]string{})
 
 	var replicas int
-	multipoolConfig, err := designate.GetMultipoolConfig(ctx, h.GetClient(), instance.Namespace)
+	multipoolConfig, err := designate.GetMultipoolConfig(ctx, h.GetClient(), instance.Namespace, instance.Spec.AZAwareMode)
 	if err != nil {
 		Log.Error(err, "Failed to get multipool configuration")
 		return err

--- a/internal/controller/designatebackendbind9_multipool.go
+++ b/internal/controller/designatebackendbind9_multipool.go
@@ -1171,7 +1171,7 @@ func (r *DesignateBackendbind9Reconciler) reconcileByPoolMode(
 ) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
 
-	multipoolConfig, err := designate.GetMultipoolConfig(ctx, helper.GetClient(), instance.Namespace)
+	multipoolConfig, err := designate.GetMultipoolConfig(ctx, helper.GetClient(), instance.Namespace, "")
 	if err != nil {
 		Log.Error(err, "Failed to get multipool configuration")
 		return ctrl.Result{}, err

--- a/internal/designate/generate_bind9_pools_yaml.go
+++ b/internal/designate/generate_bind9_pools_yaml.go
@@ -51,6 +51,8 @@ var (
 	ErrMultipoolConfigKeyMissing = errors.New("multipool ConfigMap missing pools key")
 	// ErrPoolMissingNSRecords is returned when a pool doesn't define NS records in multipool mode
 	ErrPoolMissingNSRecords = errors.New("pool missing NS records in multipool mode")
+	// ErrPoolMissingView is returned when AZ mode is enabled and a pool doesn't have a view
+	ErrPoolMissingView = errors.New("pool missing view in AZ-aware mode")
 )
 
 const (
@@ -140,7 +142,7 @@ type MultipoolConfig struct {
 
 // GetMultipoolConfig reads and parses the multipool ConfigMap
 // Returns nil if ConfigMap doesn't exist
-func GetMultipoolConfig(ctx context.Context, k8sClient client.Client, namespace string) (*MultipoolConfig, error) {
+func GetMultipoolConfig(ctx context.Context, k8sClient client.Client, namespace string, azAwareMode designatev1.DesignateAZMode) (*MultipoolConfig, error) {
 	configMap := &corev1.ConfigMap{}
 	err := k8sClient.Get(ctx, types.NamespacedName{
 		Name:      MultipoolConfigMapName,
@@ -171,7 +173,7 @@ func GetMultipoolConfig(ctx context.Context, k8sClient client.Client, namespace 
 
 	config := &MultipoolConfig{Pools: pools}
 
-	if err := validateMultipoolConfig(config); err != nil {
+	if err := validateMultipoolConfig(config, azAwareMode); err != nil {
 		return nil, fmt.Errorf("invalid multipool config: %w", err)
 	}
 
@@ -179,7 +181,7 @@ func GetMultipoolConfig(ctx context.Context, k8sClient client.Client, namespace 
 }
 
 // validateMultipoolConfig validates the multipool configuration
-func validateMultipoolConfig(config *MultipoolConfig) error {
+func validateMultipoolConfig(config *MultipoolConfig, azAwareMode designatev1.DesignateAZMode) error {
 	if len(config.Pools) == 0 {
 		return ErrNoPoolsDefined
 	}
@@ -207,6 +209,14 @@ func validateMultipoolConfig(config *MultipoolConfig) error {
 		// Validate bindReplicas must be greater than 0
 		if pool.BindReplicas <= 0 {
 			return fmt.Errorf("%w: pool %s has %d", ErrInvalidBindReplicas, pool.Name, pool.BindReplicas)
+		}
+
+		// AZ-aware mode validations
+		if azAwareMode == designatev1.AZModeEnabled {
+			if pool.View == "" {
+				return fmt.Errorf("%w: pool %s", ErrPoolMissingView, pool.Name)
+			}
+			// TODO: Validate pool TSIGKeyID is non-empty once per-pool TSIG keys are implemented
 		}
 	}
 

--- a/internal/designate/generate_bind9_pools_yaml_test.go
+++ b/internal/designate/generate_bind9_pools_yaml_test.go
@@ -145,7 +145,120 @@ func TestValidateMultipoolConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateMultipoolConfig(tt.config)
+			err := validateMultipoolConfig(tt.config, "")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateMultipoolConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" {
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("validateMultipoolConfig() error = %v, want error containing %v", err, tt.errMsg)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateMultipoolConfigAZMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *MultipoolConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid AZ config with views on all pools",
+			config: &MultipoolConfig{
+				Pools: []PoolConfig{
+					{
+						Name:         "default",
+						BindReplicas: 2,
+						View:         "default",
+						NSRecords: []designatev1.DesignateNSRecord{
+							{Hostname: "ns1.example.org.", Priority: 1},
+						},
+					},
+					{
+						Name:         "pool1",
+						BindReplicas: 2,
+						View:         "az1-view",
+						NSRecords: []designatev1.DesignateNSRecord{
+							{Hostname: "ns2.example.org.", Priority: 1},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple pools sharing same view is valid",
+			config: &MultipoolConfig{
+				Pools: []PoolConfig{
+					{
+						Name:         "default",
+						BindReplicas: 2,
+						View:         "shared-view",
+						NSRecords: []designatev1.DesignateNSRecord{
+							{Hostname: "ns1.example.org.", Priority: 1},
+						},
+					},
+					{
+						Name:         "pool1",
+						BindReplicas: 2,
+						View:         "shared-view",
+						NSRecords: []designatev1.DesignateNSRecord{
+							{Hostname: "ns2.example.org.", Priority: 1},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "reject pool missing view in AZ mode",
+			config: &MultipoolConfig{
+				Pools: []PoolConfig{
+					{
+						Name:         "default",
+						BindReplicas: 2,
+						View:         "default",
+						NSRecords: []designatev1.DesignateNSRecord{
+							{Hostname: "ns1.example.org.", Priority: 1},
+						},
+					},
+					{
+						Name:         "pool1",
+						BindReplicas: 2,
+						NSRecords: []designatev1.DesignateNSRecord{
+							{Hostname: "ns2.example.org.", Priority: 1},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "pool missing view in AZ-aware mode",
+		},
+		{
+			name: "reject default pool missing view in AZ mode",
+			config: &MultipoolConfig{
+				Pools: []PoolConfig{
+					{
+						Name:         "default",
+						BindReplicas: 2,
+						NSRecords: []designatev1.DesignateNSRecord{
+							{Hostname: "ns1.example.org.", Priority: 1},
+						},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "pool missing view in AZ-aware mode: pool default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateMultipoolConfig(tt.config, designatev1.AZModeEnabled)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("validateMultipoolConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/test/functional/designate_multipool_test.go
+++ b/test/functional/designate_multipool_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Designate multipool controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, multipoolConfig)
 
 			// Verify multipool config can be parsed
-			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace)
+			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(config).ShouldNot(BeNil())
 			Expect(config.Pools).To(HaveLen(2))
@@ -88,7 +88,7 @@ var _ = Describe("Designate multipool controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, multipoolConfig)
 
 			// Verify only one pool exists
-			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace)
+			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(config).ShouldNot(BeNil())
 			Expect(config.Pools).To(HaveLen(1))
@@ -123,7 +123,7 @@ var _ = Describe("Designate multipool controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, multipoolConfig)
 
 			// Verify initial state
-			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace)
+			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(config.Pools).To(HaveLen(2))
 
@@ -149,7 +149,7 @@ var _ = Describe("Designate multipool controller", func() {
 			Expect(k8sClient.Update(ctx, multipoolConfig)).Should(Succeed())
 
 			// Verify new state
-			config, err = designate.GetMultipoolConfig(ctx, k8sClient, namespace)
+			config, err = designate.GetMultipoolConfig(ctx, k8sClient, namespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(config.Pools).To(HaveLen(3))
 			Expect(config.Pools[2].Name).To(Equal("pool2"))
@@ -182,7 +182,7 @@ var _ = Describe("Designate multipool controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, multipoolConfig)
 
 			// Verify replica counts
-			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace)
+			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(config.Pools).To(HaveLen(2))
 			Expect(config.Pools[0].BindReplicas).To(Equal(int32(2)))
@@ -222,7 +222,7 @@ var _ = Describe("Designate multipool controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, multipoolConfig)
 
 			// Verify attributes
-			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace)
+			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(config.Pools).To(HaveLen(2))
 			Expect(config.Pools[0].Attributes).To(HaveKeyWithValue("availability_zone", "az1"))
@@ -264,7 +264,7 @@ var _ = Describe("Designate multipool controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, multipoolConfig)
 
 			// Verify pool order matches alphabetical sorting (from code implementation)
-			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace)
+			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(config.Pools).To(HaveLen(3))
 			// Pools should be sorted alphabetically by name
@@ -304,7 +304,7 @@ var _ = Describe("Designate multipool controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, multipoolConfig)
 
 			// Verify per-pool NS records
-			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace)
+			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(config.Pools).To(HaveLen(2))
 
@@ -347,7 +347,7 @@ var _ = Describe("Designate multipool controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, multipoolConfig)
 
 			// Verify initial replica counts
-			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace)
+			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(config.Pools[0].BindReplicas).To(Equal(int32(1)))
 			Expect(config.Pools[1].BindReplicas).To(Equal(int32(1)))
@@ -368,7 +368,7 @@ var _ = Describe("Designate multipool controller", func() {
 			Expect(k8sClient.Update(ctx, multipoolConfig)).Should(Succeed())
 
 			// Verify updated replica count
-			config, err = designate.GetMultipoolConfig(ctx, k8sClient, namespace)
+			config, err = designate.GetMultipoolConfig(ctx, k8sClient, namespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(config.Pools[0].BindReplicas).To(Equal(int32(1)))
 			Expect(config.Pools[1].BindReplicas).To(Equal(int32(3)))

--- a/test/functional/designatebackendbind9_controller_test.go
+++ b/test/functional/designatebackendbind9_controller_test.go
@@ -302,7 +302,7 @@ var _ = Describe("DesignateBackendbind9 controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, multipoolConfig)
 
 			// Verify we can fetch and parse the config
-			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace)
+			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(config).ShouldNot(BeNil())
 			Expect(config.Pools).To(HaveLen(2))
@@ -313,7 +313,7 @@ var _ = Describe("DesignateBackendbind9 controller", func() {
 		})
 
 		It("should not fail if multipool ConfigMap is missing", func() {
-			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace)
+			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(config).Should(BeNil())
 		})
@@ -332,7 +332,7 @@ var _ = Describe("DesignateBackendbind9 controller", func() {
 			Expect(k8sClient.Create(ctx, invalidConfig)).Should(Succeed())
 			DeferCleanup(k8sClient.Delete, ctx, invalidConfig)
 
-			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace)
+			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace, "")
 			Expect(err).Should(HaveOccurred())
 			Expect(config).Should(BeNil())
 		})
@@ -369,7 +369,7 @@ var _ = Describe("DesignateBackendbind9 controller", func() {
 			DeferCleanup(k8sClient.Delete, ctx, multipoolConfig)
 
 			// Fetch and verify pools are sorted alphabetically
-			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace)
+			config, err := designate.GetMultipoolConfig(ctx, k8sClient, namespace, "")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(config).ShouldNot(BeNil())
 			Expect(config.Pools).To(HaveLen(3))


### PR DESCRIPTION
Add AZAwareMode string enum field (DesignateAZMode type) to DesignateSpecBase with allowed values "" and "Enabled", following OpenShift API conventions. Provides a declarative way to enable AZ-aware multipool with BIND views, per-pool TSIG keys, and per-AZ Unbound instances.

Extend validateMultipoolConfig to reject pools missing a view when AZ mode is enabled. Use variadic parameter for backward compatibility with existing callers. Regenerate CRD manifests and add unit tests for AZ-aware validation rules.