### PR TITLE
18.0 fr6 Support overriding masters with mdns services 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,7 +345,7 @@ run-with-webhook: manifests generate fmt vet ## Run a controller from your host.
 
 CRD_SCHEMA_CHECKER_VERSION ?= release-4.16
 
-BRANCH ?= main
+BRANCH ?= 18.0-fr6
 .PHONY: force-bump
 force-bump: ## Force bump operator and lib-common dependencies
 	for dep in $$(cat go.mod | grep openstack-k8s-operators | grep -vE -- 'indirect|designate-operator|^replace' | awk '{print $$1}'); do \

--- a/internal/controller/designate_controller.go
+++ b/internal/controller/designate_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -109,6 +110,41 @@ func getSecret(
 	(*envVars)[prefix+secret.Name] = env.SetValue(hash)
 
 	return ctrl.Result{}, nil
+}
+
+// getExternalMasterServiceIPs returns the LoadBalancer ingress IPs for external master services
+// matching the given pool name. The second return value is true when at least one matching service
+// has no ingress IP yet, signalling that the caller should requeue and retry later.
+func getExternalMasterServiceIPs(ctx context.Context, helper *helper.Helper, instance *designatev1beta1.Designate, poolName string, Log logr.Logger) ([]string, bool, error) {
+	services := &corev1.ServiceList{}
+	err := helper.GetClient().List(ctx, services, client.InNamespace(instance.Namespace), client.MatchingLabels{
+		designate.ExternalMasterServiceLabel: "true",
+		"service":                            "designate-mdns",
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	ips := make([]string, 0, len(services.Items))
+	pendingIngress := false
+	for _, service := range services.Items {
+		if service.Spec.Type != corev1.ServiceTypeLoadBalancer {
+			continue
+		}
+		// If the service is missing the annotation, apply to all pools by skipping the pool name check.
+		servicePool, ok := service.Annotations[designate.ExternalPoolServiceAnnotation]
+		if ok && servicePool != poolName {
+			continue
+		}
+
+		if len(service.Status.LoadBalancer.Ingress) == 0 {
+			Log.Info(fmt.Sprintf("External master Service %s/%s has no LoadBalancer ingress IP yet, will requeue", service.Namespace, service.Name))
+			pendingIngress = true
+			continue
+		}
+		ips = append(ips, service.Status.LoadBalancer.Ingress[0].IP)
+	}
+	sort.Strings(ips)
+	return ips, pendingIngress, nil
 }
 
 // GetClient -
@@ -299,6 +335,7 @@ func (r *DesignateReconciler) validatePoolRemovals(
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=anyuid;privileged,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups="",resources=pods,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups="",resources=pods/log,verbs=get
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch
 
 // Reconcile -
 func (r *DesignateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, _err error) {
@@ -503,6 +540,25 @@ func (r *DesignateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		return result
 	}
 
+	externalMasterServiceFn := func(ctx context.Context, o client.Object) []reconcile.Request {
+		if o.GetLabels()[designate.ExternalMasterServiceLabel] != "true" {
+			return nil
+		}
+
+		designates := &designatev1beta1.DesignateList{}
+		if err := r.List(ctx, designates, client.InNamespace(o.GetNamespace())); err != nil {
+			Log.Error(err, "Unable to retrieve Designate CRs")
+			return nil
+		}
+		var result []reconcile.Request
+		for _, cr := range designates.Items {
+			result = append(result, reconcile.Request{
+				NamespacedName: client.ObjectKey{Namespace: o.GetNamespace(), Name: cr.Name},
+			})
+		}
+		return result
+	}
+
 	// TODO(beagles):
 	// - Watch for changes to the redis PODs and resync the headless hostnames for the PODs if necessary.
 	return ctrl.NewControllerManagedBy(mgr).
@@ -539,6 +595,12 @@ func (r *DesignateReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 		Watches(
 			&redisv1.Redis{},
 			handler.EnqueueRequestsFromMapFunc(redisWatchFn),
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+		).
+		// Watch for external master Service changes (LoadBalancer IP assignments)
+		Watches(
+			&corev1.Service{},
+			handler.EnqueueRequestsFromMapFunc(externalMasterServiceFn),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
 		).
 		Complete(r)
@@ -1005,6 +1067,7 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 
 	externalBindData := make(map[string][]designate.ExternalBind)
 	externalRndcSecretData := make(map[string]string)
+	externalMasterServiceIPs := make(map[string][]string)
 	updateRndcSecret := false
 
 	if instance.Spec.ExternalBindsSecret != "" {
@@ -1048,9 +1111,18 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 				externalBindData[poolName][i].RndcFile = rndcFilename
 				externalRndcSecretData[rndcFilename] = rndcBlock
 			}
+			var pendingIngress bool
+			externalMasterServiceIPs[poolName], pendingIngress, err = getExternalMasterServiceIPs(ctx, helper, instance, poolName, Log)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			if pendingIngress {
+				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+			}
 		}
 		updateRndcSecret = hash != instance.Status.Hash[designate.ExternalBindsData]
 		instance.Status.Hash[designate.ExternalBindsData] = hash
+
 	} else {
 		// No external binds secret, so we need to check if the external rndc secret data is present
 		// and if it is - remove the contents so the workers have up to date.
@@ -1265,7 +1337,7 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 			Data: make(map[string]string),
 		}
 
-		poolsYaml, poolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(updatedBindMap, mdnsConfigMap.Data, nsRecords, multipoolConfig, externalBindData)
+		poolsYaml, poolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(updatedBindMap, mdnsConfigMap.Data, nsRecords, multipoolConfig, externalBindData, externalMasterServiceIPs)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/designate/const.go
+++ b/internal/designate/const.go
@@ -114,4 +114,18 @@ const (
 	// ExternalRndcData is the name of the secret for mounting the external binds rndc keys
 	// in the workers.
 	ExternalRndcData = "designate-external-rndc"
+
+	// Fields for Service objects for accessing mDNS/DNS masters from outside the cluster for
+	// external DNS secondaries. Why a label AND an annotation? The label is used to identify the
+	// service as an external master, while the annotation is used to specify the pool name the
+	// external service is intended for. This allows different pools to have different masters
+	// and be configured with different networking as needed.
+
+	// ExternalMasterServiceLabel is the label name for identifying services to be as mDNS
+	// endpoints
+	ExternalMasterServiceLabel = "designate.openstack.org/external_master"
+
+	// ExternalPoolServiceAnnotation is the annotation name for specifying the pool name the external
+	// service is intended for
+	ExternalPoolServiceAnnotation = "designate.openstack.org/external_pool"
 )

--- a/internal/designate/generate_bind9_pools_yaml.go
+++ b/internal/designate/generate_bind9_pools_yaml.go
@@ -229,7 +229,7 @@ func validateMultipoolConfig(config *MultipoolConfig, azAwareMode designatev1.De
 }
 
 // GeneratePoolsYamlDataAndHash sorts all pool resources to get the correct hash every time
-func GeneratePoolsYamlDataAndHash(BindMap, MdnsMap map[string]string, nsRecords []designatev1.DesignateNSRecord, multipoolConfig *MultipoolConfig, externalBinds map[string][]ExternalBind) (string, string, error) {
+func GeneratePoolsYamlDataAndHash(BindMap, MdnsMap map[string]string, nsRecords []designatev1.DesignateNSRecord, multipoolConfig *MultipoolConfig, externalBinds map[string][]ExternalBind, externalMasterServiceIPs map[string][]string) (string, string, error) {
 	masterHosts := make([]string, 0, len(MdnsMap))
 	for _, host := range MdnsMap {
 		masterHosts = append(masterHosts, host)
@@ -239,7 +239,7 @@ func GeneratePoolsYamlDataAndHash(BindMap, MdnsMap map[string]string, nsRecords 
 	var pools []Pool
 
 	if multipoolConfig == nil {
-		pool, err := generateDefaultPool(BindMap, masterHosts, nsRecords, externalBinds["default"])
+		pool, err := generateDefaultPool(BindMap, masterHosts, nsRecords, externalBinds["default"], externalMasterServiceIPs["default"])
 		if err != nil {
 			return "", "", err
 		}
@@ -348,7 +348,7 @@ func createExternalTargetAndNameserver(bindInfo ExternalBind, masters []Master, 
 	return target, nameserver
 }
 
-func generateDefaultPool(BindMap map[string]string, masterHosts []string, nsRecords []designatev1.DesignateNSRecord, externalBinds []ExternalBind) (Pool, error) {
+func generateDefaultPool(BindMap map[string]string, masterHosts []string, nsRecords []designatev1.DesignateNSRecord, externalBinds []ExternalBind, externalMasterServiceIPs []string) (Pool, error) {
 	sortNSRecords(nsRecords)
 
 	bindIPs := make([]string, len(BindMap))
@@ -364,11 +364,14 @@ func generateDefaultPool(BindMap map[string]string, masterHosts []string, nsReco
 		targets[i], nameservers[i] = createTargetAndNameserver(bindIPs[i], i, masters, description, "", "")
 	}
 
-	// NOTE: external BIND9 servers inherit the internal mDNS masters list. These masters may not be
-	// reachable from an external network — the deployer must ensure connectivity (e.g. via NAT, an
-	// exposed mDNS endpoint, or custom master addresses in a future iteration of this feature).
 	externalTargets := make([]Target, len(externalBinds))
 	externalNameservers := make([]Nameserver, len(externalBinds))
+	// Prefer external master service IPs as masters if available; fallback to internal masters if not (may require additional network routing/configuration by the admin).
+	if len(externalMasterServiceIPs) > 0 {
+		masters = createMasters(externalMasterServiceIPs)
+	} else {
+		masters = createMasters(masterHosts)
+	}
 	for i := range externalBinds {
 		description := fmt.Sprintf("External BIND9 Server %d (%s)", i, externalBinds[i].Name)
 		externalTargets[i], externalNameservers[i] = createExternalTargetAndNameserver(externalBinds[i], masters, description)

--- a/internal/designate/generate_bind9_pools_yaml_test.go
+++ b/internal/designate/generate_bind9_pools_yaml_test.go
@@ -283,7 +283,7 @@ func TestGenerateDefaultPool(t *testing.T) {
 		{Hostname: "ns2.example.org.", Priority: 2},
 	}
 
-	pool, err := generateDefaultPool(bindMap, masterHosts, nsRecords, []ExternalBind{})
+	pool, err := generateDefaultPool(bindMap, masterHosts, nsRecords, []ExternalBind{}, []string{})
 	if err != nil {
 		t.Fatalf("generateDefaultPool() error = %v", err)
 	}
@@ -457,7 +457,7 @@ func TestSinglePoolModeUsesCRNSRecords(t *testing.T) {
 	}
 
 	// In single-pool mode, generateDefaultPool should use CR NS records
-	pool, err := generateDefaultPool(bindMap, masterHosts, crNSRecords, []ExternalBind{})
+	pool, err := generateDefaultPool(bindMap, masterHosts, crNSRecords, []ExternalBind{}, []string{})
 	if err != nil {
 		t.Fatalf("generateDefaultPool() error = %v", err)
 	}
@@ -602,7 +602,7 @@ func TestGenerateDefaultPoolWithExternalBinds(t *testing.T) {
 		},
 	}
 
-	pool, err := generateDefaultPool(bindMap, masterHosts, nsRecords, externalBinds)
+	pool, err := generateDefaultPool(bindMap, masterHosts, nsRecords, externalBinds, []string{})
 	if err != nil {
 		t.Fatalf("generateDefaultPool() error = %v", err)
 	}
@@ -675,7 +675,7 @@ func TestGenerateDefaultPoolWithMultipleExternalBinds(t *testing.T) {
 		},
 	}
 
-	pool, err := generateDefaultPool(bindMap, masterHosts, nsRecords, externalBinds)
+	pool, err := generateDefaultPool(bindMap, masterHosts, nsRecords, externalBinds, []string{})
 	if err != nil {
 		t.Fatalf("generateDefaultPool() error = %v", err)
 	}
@@ -733,7 +733,7 @@ func TestGenerateDefaultPoolWithExternalBindsFromYAML(t *testing.T) {
 	}
 	parsedBinds[0].RndcFile = "default-rndc-0"
 
-	pool, err := generateDefaultPool(bindMap, masterHosts, nsRecords, parsedBinds)
+	pool, err := generateDefaultPool(bindMap, masterHosts, nsRecords, parsedBinds, []string{})
 	if err != nil {
 		t.Fatalf("generateDefaultPool() error = %v", err)
 	}

--- a/test/functional/base_test.go
+++ b/test/functional/base_test.go
@@ -50,7 +50,9 @@ const (
 	ExternalBindAddress         = "192.168.100.50"
 	ExternalBindName            = "bind9-external"
 	// Fake RNDC secret for functional tests only; not a real credential.
-	ExternalRndcSecretValue = "c2VjcmV0MTIz" // #nosec G101
+	ExternalRndcSecretValue    = "c2VjcmV0MTIz" // #nosec G101
+	ExternalMasterServiceIP    = "10.0.0.100"
+	ExternalMasterServiceAltIP = "10.0.0.101"
 
 	PublicCertSecretName   = "public-tls-certs"   // #nosec G101
 	InternalCertSecretName = "internal-tls-certs" // #nosec G101
@@ -636,6 +638,44 @@ func CreateExternalBindsSecret(name types.NamespacedName) *corev1.Secret {
 func createAndSimulateExternalBinds(secretName types.NamespacedName) {
 	secret := CreateExternalBindsSecret(secretName)
 	DeferCleanup(k8sClient.Delete, ctx, secret)
+}
+
+func createExternalMasterService(ns, name, poolAnnotation, ingressIP string) *corev1.Service {
+	labels := map[string]string{
+		designate.ExternalMasterServiceLabel: "true",
+		"service":                            "designate-mdns",
+	}
+	annotations := map[string]string{}
+	if poolAnnotation != "" {
+		annotations[designate.ExternalPoolServiceAnnotation] = poolAnnotation
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   ns,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeLoadBalancer,
+			Ports: []corev1.ServicePort{
+				{Name: "mdns", Port: 5354},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, svc)).Should(Succeed())
+
+	if ingressIP != "" {
+		Eventually(func(g Gomega) {
+			current := &corev1.Service{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(svc), current)).Should(Succeed())
+			current.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: ingressIP}}
+			g.Expect(k8sClient.Status().Update(ctx, current)).Should(Succeed())
+		}, timeout, interval).Should(Succeed())
+	}
+
+	DeferCleanup(k8sClient.Delete, ctx, svc)
+	return svc
 }
 
 func CreateDesignateNSRecordsConfigMap(name types.NamespacedName) client.Object {

--- a/test/functional/designate_controller_test.go
+++ b/test/functional/designate_controller_test.go
@@ -848,12 +848,12 @@ var _ = Describe("Designate controller", func() {
 				allNSRecords = append(allNSRecords, nsRecords...)
 			}
 
-			_, poolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, allNSRecords, nil, make(map[string][]designate.ExternalBind))
+			_, poolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, allNSRecords, nil, make(map[string][]designate.ExternalBind), make(map[string][]string))
 			Expect(err).ToNot(HaveOccurred())
 
 			// we used to have inconsistent ordering, so generate the pools.yaml 10 times and make sure it is has exactly the same content
 			for range 10 {
-				_, newPoolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, allNSRecords, nil, make(map[string][]designate.ExternalBind))
+				_, newPoolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, allNSRecords, nil, make(map[string][]designate.ExternalBind), make(map[string][]string))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(poolsYamlHash).Should(Equal(newPoolsYamlHash))
 			}
@@ -1120,6 +1120,192 @@ var _ = Describe("Designate controller", func() {
 
 				designateCR := GetDesignate(designateName)
 				g.Expect(designateCR.Status.Hash[designate.ExternalBindsData]).To(BeEmpty())
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	When("Designate has external BIND9 with external master services", func() {
+		var externalBindsSecretName types.NamespacedName
+
+		BeforeEach(func() {
+			externalBindsSecretName = types.NamespacedName{
+				Namespace: namespace,
+				Name:      ExternalBindsSecretTestName,
+			}
+			spec["externalBindsSecret"] = ExternalBindsSecretTestName
+
+			createAndSimulateKeystone(designateName)
+			createAndSimulateRedis(designateRedisName)
+			createAndSimulateDesignateSecrets(designateName)
+			createAndSimulateTransportURL(transportURLName, transportURLSecretName)
+			createAndSimulateDB(spec)
+			createAndSimulateExternalBinds(externalBindsSecretName)
+
+			DeferCleanup(k8sClient.Delete, ctx, CreateNAD(types.NamespacedName{
+				Name:      spec["designateNetworkAttachment"].(string),
+				Namespace: namespace,
+			}))
+			DeferCleanup(th.DeleteInstance, CreateDesignate(designateName, spec))
+			th.SimulateJobSuccess(designateDBSyncName)
+
+			createAndSimulateBind9(designateBind9Name)
+			createAndSimulateMdns(designateMdnsName)
+			createAndSimulateNSRecordsConfigMap(designateNSRecordConfigMapName)
+			simulateCentralReadyCount(designateName, 1)
+		})
+
+		It("uses external master service IPs as masters for external targets in pools.yaml", func() {
+			createExternalMasterService(namespace, "mdns-external-lb", "default", ExternalMasterServiceIP)
+
+			Eventually(func(g Gomega) {
+				poolsYamlConfigMap := th.GetConfigMap(types.NamespacedName{
+					Name:      designate.PoolsYamlConfigMap,
+					Namespace: namespace,
+				})
+				g.Expect(poolsYamlConfigMap).ToNot(BeNil())
+
+				var pools []designate.Pool
+				err := yaml.Unmarshal([]byte(poolsYamlConfigMap.Data[designate.PoolsYamlContent]), &pools)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(pools).To(HaveLen(1))
+
+				pool := pools[0]
+				g.Expect(pool.Targets).To(HaveLen(bind9ReplicaCount + 1))
+
+				externalTarget := pool.Targets[len(pool.Targets)-1]
+				g.Expect(externalTarget.Description).To(ContainSubstring("External BIND9 Server"))
+				g.Expect(externalTarget.Masters).To(HaveLen(1))
+				g.Expect(externalTarget.Masters[0].Host).To(Equal(ExternalMasterServiceIP))
+
+				// Internal targets should still use internal mDNS masters
+				internalTarget := pool.Targets[0]
+				g.Expect(internalTarget.Masters).To(HaveLen(mdnsReplicaCount))
+				for _, master := range internalTarget.Masters {
+					g.Expect(master.Host).ToNot(Equal(ExternalMasterServiceIP))
+				}
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("requeues and then uses external master service IP once ingress is assigned", func() {
+			svc := createExternalMasterService(namespace, "mdns-external-lb-no-ip", "default", "")
+
+			// While the service has no ingress IP the controller requeues without updating
+			// pools.yaml, so the configmap either doesn't exist yet or must not
+			// contain the external master service IP.
+			Consistently(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      designate.PoolsYamlConfigMap,
+					Namespace: namespace,
+				}, cm)
+				if k8s_errors.IsNotFound(err) {
+					return
+				}
+				g.Expect(err).ToNot(HaveOccurred())
+				var pools []designate.Pool
+				err = yaml.Unmarshal([]byte(cm.Data[designate.PoolsYamlContent]), &pools)
+				if err != nil || len(pools) == 0 {
+					return
+				}
+				externalTarget := pools[0].Targets[len(pools[0].Targets)-1]
+				for _, master := range externalTarget.Masters {
+					g.Expect(master.Host).ToNot(Equal(ExternalMasterServiceIP))
+				}
+			}, timeout, interval).Should(Succeed())
+
+			// Now assign the ingress IP — the service watch triggers reconciliation.
+			Eventually(func(g Gomega) {
+				current := &corev1.Service{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: svc.Name, Namespace: svc.Namespace}, current)).Should(Succeed())
+				current.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: ExternalMasterServiceIP}}
+				g.Expect(k8sClient.Status().Update(ctx, current)).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				poolsYamlConfigMap := th.GetConfigMap(types.NamespacedName{
+					Name:      designate.PoolsYamlConfigMap,
+					Namespace: namespace,
+				})
+				g.Expect(poolsYamlConfigMap).ToNot(BeNil())
+
+				var pools []designate.Pool
+				err := yaml.Unmarshal([]byte(poolsYamlConfigMap.Data[designate.PoolsYamlContent]), &pools)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(pools).To(HaveLen(1))
+
+				externalTarget := pools[0].Targets[len(pools[0].Targets)-1]
+				g.Expect(externalTarget.Description).To(ContainSubstring("External BIND9 Server"))
+				g.Expect(externalTarget.Masters).To(HaveLen(1))
+				g.Expect(externalTarget.Masters[0].Host).To(Equal(ExternalMasterServiceIP))
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("only uses services matching the pool annotation", func() {
+			createExternalMasterService(namespace, "mdns-lb-default", "default", ExternalMasterServiceIP)
+			createExternalMasterService(namespace, "mdns-lb-other", "other-pool", ExternalMasterServiceAltIP)
+
+			Eventually(func(g Gomega) {
+				poolsYamlConfigMap := th.GetConfigMap(types.NamespacedName{
+					Name:      designate.PoolsYamlConfigMap,
+					Namespace: namespace,
+				})
+				g.Expect(poolsYamlConfigMap).ToNot(BeNil())
+
+				var pools []designate.Pool
+				err := yaml.Unmarshal([]byte(poolsYamlConfigMap.Data[designate.PoolsYamlContent]), &pools)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(pools).To(HaveLen(1))
+
+				pool := pools[0]
+				externalTarget := pool.Targets[len(pool.Targets)-1]
+				g.Expect(externalTarget.Masters).To(HaveLen(1))
+				g.Expect(externalTarget.Masters[0].Host).To(Equal(ExternalMasterServiceIP))
+				// The "other-pool" service IP should NOT appear
+				for _, master := range externalTarget.Masters {
+					g.Expect(master.Host).ToNot(Equal(ExternalMasterServiceAltIP))
+				}
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("updates pools.yaml when external master service appears after initial reconciliation", func() {
+			// First, verify external targets use internal mDNS masters (no service present yet)
+			Eventually(func(g Gomega) {
+				poolsYamlConfigMap := th.GetConfigMap(types.NamespacedName{
+					Name:      designate.PoolsYamlConfigMap,
+					Namespace: namespace,
+				})
+				g.Expect(poolsYamlConfigMap).ToNot(BeNil())
+
+				var pools []designate.Pool
+				err := yaml.Unmarshal([]byte(poolsYamlConfigMap.Data[designate.PoolsYamlContent]), &pools)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				pool := pools[0]
+				externalTarget := pool.Targets[len(pool.Targets)-1]
+				g.Expect(externalTarget.Description).To(ContainSubstring("External BIND9 Server"))
+				g.Expect(externalTarget.Masters).To(HaveLen(mdnsReplicaCount))
+			}, timeout, interval).Should(Succeed())
+
+			// Now create the external master service — the controller watch should trigger reconciliation
+			createExternalMasterService(namespace, "mdns-external-late", "default", ExternalMasterServiceIP)
+
+			simulateCentralReadyCount(designateName, 1)
+
+			Eventually(func(g Gomega) {
+				poolsYamlConfigMap := th.GetConfigMap(types.NamespacedName{
+					Name:      designate.PoolsYamlConfigMap,
+					Namespace: namespace,
+				})
+				g.Expect(poolsYamlConfigMap).ToNot(BeNil())
+
+				var pools []designate.Pool
+				err := yaml.Unmarshal([]byte(poolsYamlConfigMap.Data[designate.PoolsYamlContent]), &pools)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				pool := pools[0]
+				externalTarget := pool.Targets[len(pool.Targets)-1]
+				g.Expect(externalTarget.Masters).To(HaveLen(1))
+				g.Expect(externalTarget.Masters[0].Host).To(Equal(ExternalMasterServiceIP))
 			}, timeout, interval).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
If mDNS services with the appropriate labelling are present, then override the masters for external targets with those IPs.