### PR TITLE
Add per-pool TSIG key creation gated by AZAwareMode

### DIFF
--- a/internal/controller/designate_controller.go
+++ b/internal/controller/designate_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -1337,7 +1338,26 @@ func (r *DesignateReconciler) reconcileNormal(ctx context.Context, instance *des
 			Data: make(map[string]string),
 		}
 
-		poolsYaml, poolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(updatedBindMap, mdnsConfigMap.Data, nsRecords, multipoolConfig, externalBindData, externalMasterServiceIPs)
+		// Read per-pool TSIG key ID mapping if AZ-aware mode is enabled
+		var tsigKeyIDs map[string]string
+		if instance.Spec.AZAwareMode == designatev1beta1.AZModeEnabled && multipoolConfig != nil {
+			tsigSecretName := fmt.Sprintf("%s-backendbind9%s", instance.Name, designate.TsigSecretSuffix)
+			tsigSecret := &corev1.Secret{}
+			err := helper.GetClient().Get(ctx, types.NamespacedName{Name: tsigSecretName, Namespace: instance.GetNamespace()}, tsigSecret)
+			if err != nil && !k8s_errors.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf("failed to get TSIG secret %s: %w", tsigSecretName, err)
+			}
+			if err == nil {
+				if data, exists := tsigSecret.Data[designate.TSIGKeyIDsDataKey]; exists {
+					if jsonErr := json.Unmarshal(data, &tsigKeyIDs); jsonErr != nil {
+						Log.Info(fmt.Sprintf("Failed to parse TSIG key ID mapping from secret, pools.yaml will be generated without tsigkey_ids: %v", jsonErr))
+					}
+				}
+			}
+			// If secret doesn't exist yet, tsigKeyIDs stays nil — pools.yaml is generated without tsigkey_ids (first pass)
+		}
+
+		poolsYaml, poolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(updatedBindMap, mdnsConfigMap.Data, nsRecords, multipoolConfig, externalBindData, externalMasterServiceIPs, tsigKeyIDs)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controller/designatebackendbind9_multipool.go
+++ b/internal/controller/designatebackendbind9_multipool.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -734,18 +735,162 @@ func (r *DesignateBackendbind9Reconciler) cleanupOrphanedStatefulSets(
 // TSIG Secret Management
 // ============================================================================
 
-// reconcileTSIGSecrets creates/updates a single TSIG secret for all non-default pools in multipool mode
-// TSIG (Transaction Signature) authentication is required for mdns to communicate with
-// non-default pool BIND servers.
-// This creates ONE secret containing TSIG keys for ALL non-default pools.
+// reconcileTSIGSecrets manages TSIG secrets for multipool mode.
+// When AZAwareMode=Enabled: creates per-pool TSIG keys (one per pool including default).
+// Otherwise: uses the shared TSIG key model (one key for all non-default pools).
 func (r *DesignateBackendbind9Reconciler) reconcileTSIGSecrets(
 	ctx context.Context,
 	instance *designatev1beta1.DesignateBackendbind9,
 	helper *helper.Helper,
 	multipoolConfig *designate.MultipoolConfig,
 ) (ctrl.Result, error) {
+	// Determine AZ-aware mode from parent Designate CR
+	designateInstance, err := r.getDesignateCR(ctx, helper, instance)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get parent Designate CR for AZ mode check: %w", err)
+	}
+
+	if designateInstance.Spec.AZAwareMode == designatev1beta1.AZModeEnabled {
+		return r.reconcilePerPoolTSIGSecrets(ctx, instance, helper, multipoolConfig)
+	}
+
+	return r.reconcileSharedTSIGSecret(ctx, instance, helper, multipoolConfig)
+}
+
+// reconcilePerPoolTSIGSecrets creates per-pool TSIG keys and stores them in a Secret.
+// Every pool (including default) gets its own TSIG key with scope=POOL and resource_id=pool-UUID.
+func (r *DesignateBackendbind9Reconciler) reconcilePerPoolTSIGSecrets(
+	ctx context.Context,
+	instance *designatev1beta1.DesignateBackendbind9,
+	helper *helper.Helper,
+	multipoolConfig *designate.MultipoolConfig,
+) (ctrl.Result, error) {
 	Log := r.GetLogger(ctx)
-	Log.Info("Reconciling TSIG secret for multipool")
+	Log.Info("Reconciling per-pool TSIG secrets (AZ-aware mode)")
+
+	tsigSecretName := instance.Name + designate.TsigSecretSuffix
+
+	// Get mDNS IPs — needed for hash computation and config generation
+	mdnsIPs, err := r.getMdnsIPsForTSIG(ctx, helper, instance.Namespace)
+	if err != nil {
+		if k8s_errors.IsNotFound(err) {
+			Log.Info("mdns-ip-map ConfigMap not found yet, will requeue in 30 seconds")
+			return ctrl.Result{RequeueAfter: time.Second * 30}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// Check pool config hash to avoid unnecessary work
+	poolConfigHash, err := r.getPerPoolConfigHash(multipoolConfig, mdnsIPs)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	existingSecret := &corev1.Secret{}
+	err = helper.GetClient().Get(ctx, types.NamespacedName{Name: tsigSecretName, Namespace: instance.Namespace}, existingSecret)
+	if err == nil {
+		if existingHash, exists := existingSecret.Annotations["pool-config-hash"]; exists && existingHash == poolConfigHash {
+			Log.Info("Per-pool TSIG secret is up to date (pool config unchanged)")
+			return ctrl.Result{}, nil
+		}
+	} else if !k8s_errors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+
+	// Create per-pool TSIG keys in Designate
+	tsigKeys, err := r.ensurePerPoolTSIGKeys(ctx, helper, instance, multipoolConfig)
+	if err != nil {
+		if errors.Is(err, designate.ErrKeystoneNotReady) ||
+			errors.Is(err, designate.ErrPoolListJobNotComplete) || errors.Is(err, designate.ErrPoolListJobFailed) ||
+			errors.Is(err, designate.ErrNoPoolsFound) {
+			Log.Info(fmt.Sprintf("Dependencies not ready for per-pool TSIG key creation, will requeue in 30 seconds: %v", err))
+			return ctrl.Result{RequeueAfter: time.Second * 30}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if len(tsigKeys) == 0 {
+		Log.Info("No pools registered in Designate yet, will requeue in 30 seconds")
+		return ctrl.Result{RequeueAfter: time.Second * 30}, nil
+	}
+
+	// Clean up TSIG keys for pools that were removed from the config
+	if cleanupErr := r.cleanupOrphanedPerPoolTSIGKeys(ctx, helper, instance, multipoolConfig); cleanupErr != nil {
+		Log.Error(cleanupErr, "Failed to cleanup orphaned per-pool TSIG keys (non-fatal)")
+	}
+
+	// Generate BIND TSIG config with per-pool key blocks
+	tsigConfigContent := r.generatePerPoolTSIGConfig(tsigKeys, mdnsIPs)
+
+	// Build and write the per-pool TSIG secret
+	if err := r.createOrUpdatePerPoolTSIGSecret(ctx, helper, instance, tsigKeys, tsigConfigContent, poolConfigHash); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	Log.Info(fmt.Sprintf("Per-pool TSIG secret %s reconciled (hash: %s, pools: %d)", tsigSecretName, poolConfigHash, len(tsigKeys)))
+	return ctrl.Result{}, nil
+}
+
+// createOrUpdatePerPoolTSIGSecret writes the per-pool TSIG config and key ID mapping to a Secret.
+func (r *DesignateBackendbind9Reconciler) createOrUpdatePerPoolTSIGSecret(
+	ctx context.Context,
+	helper *helper.Helper,
+	instance *designatev1beta1.DesignateBackendbind9,
+	tsigKeys map[string]*designate.TSIGKey,
+	tsigConfigContent string,
+	poolConfigHash string,
+) error {
+	tsigSecretName := instance.Name + designate.TsigSecretSuffix
+
+	tsigKeyIDMapping := make(map[string]string)
+	for poolName, key := range tsigKeys {
+		tsigKeyIDMapping[poolName] = key.ID
+	}
+	tsigKeyIDsJSON, err := json.Marshal(tsigKeyIDMapping)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tsigkey_id mapping: %w", err)
+	}
+
+	tsigSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tsigSecretName,
+			Namespace: instance.Namespace,
+			Labels: map[string]string{
+				"service":   "designate-backendbind9",
+				"component": "designate-backendbind9",
+			},
+		},
+	}
+
+	_, err = controllerutil.CreateOrPatch(ctx, helper.GetClient(), tsigSecret, func() error {
+		tsigSecret.Type = corev1.SecretTypeOpaque
+		tsigSecret.StringData = map[string]string{
+			"tsigkeys.conf":             tsigConfigContent,
+			designate.TSIGKeyIDsDataKey: string(tsigKeyIDsJSON),
+		}
+		if tsigSecret.Annotations == nil {
+			tsigSecret.Annotations = make(map[string]string)
+		}
+		tsigSecret.Annotations["pool-config-hash"] = poolConfigHash
+		tsigSecret.Annotations["tsig-mode"] = "per-pool"
+		return controllerutil.SetControllerReference(instance, tsigSecret, r.Scheme)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create/update per-pool TSIG secret: %w", err)
+	}
+
+	return nil
+}
+
+// reconcileSharedTSIGSecret implements the original shared TSIG key model for non-AZ deployments.
+func (r *DesignateBackendbind9Reconciler) reconcileSharedTSIGSecret(
+	ctx context.Context,
+	instance *designatev1beta1.DesignateBackendbind9,
+	helper *helper.Helper,
+	multipoolConfig *designate.MultipoolConfig,
+) (ctrl.Result, error) {
+	Log := r.GetLogger(ctx)
+	Log.Info("Reconciling shared TSIG secret for multipool")
 
 	// Early exit: Check if there are any non-default pools that need TSIG
 	// Pool 0 (default) doesn't need TSIG, so only pools 1+ require it
@@ -801,10 +946,18 @@ func (r *DesignateBackendbind9Reconciler) reconcileTSIGSecrets(
 	existingSecret := &corev1.Secret{}
 	err = helper.GetClient().Get(ctx, types.NamespacedName{Name: tsigSecretName, Namespace: instance.Namespace}, existingSecret)
 	if err == nil {
-		// Secret exists - check if pool config hash matches
-		if existingHash, exists := existingSecret.Annotations["pool-config-hash"]; exists && existingHash == poolConfigHash {
-			Log.Info("TSIG secret is up to date (pool config unchanged)")
-			return ctrl.Result{}, nil
+		// Force re-write if per-pool artifacts are present (transition from per-pool to shared)
+		_, hasPerPoolAnnotation := existingSecret.Annotations["tsig-mode"]
+		_, hasPerPoolData := existingSecret.Data[designate.TSIGKeyIDsDataKey]
+		needsCleanup := hasPerPoolAnnotation || hasPerPoolData
+
+		if !needsCleanup {
+			if existingHash, exists := existingSecret.Annotations["pool-config-hash"]; exists && existingHash == poolConfigHash {
+				Log.Info("TSIG secret is up to date (pool config unchanged)")
+				return ctrl.Result{}, nil
+			}
+		} else {
+			Log.Info("Per-pool TSIG artifacts detected in shared mode, forcing secret re-write")
 		}
 	} else if !k8s_errors.IsNotFound(err) {
 		return ctrl.Result{}, err
@@ -826,8 +979,7 @@ func (r *DesignateBackendbind9Reconciler) reconcileTSIGSecrets(
 	// Get or create shared TSIG key for all non-default pools
 	tsigKey, err := r.ensureSharedTSIGKey(ctx, helper, instance.Namespace)
 	if err != nil {
-		// Check if error is due to services not being ready
-		if strings.Contains(err.Error(), "not ready") || strings.Contains(err.Error(), "no running") {
+		if errors.Is(err, designate.ErrKeystoneNotReady) {
 			Log.Info("Required services not ready for TSIG key retrieval, will requeue in 30 seconds")
 			return ctrl.Result{RequeueAfter: time.Second * 30}, nil
 		}
@@ -920,12 +1072,175 @@ func (r *DesignateBackendbind9Reconciler) ensureSharedTSIGKey(
 	return tsigKey, nil
 }
 
+// ensurePerPoolTSIGKeys creates or retrieves a TSIG key for each pool (including default).
+// Returns a map of pool-name -> tsigkey-id (Designate UUID).
+func (r *DesignateBackendbind9Reconciler) ensurePerPoolTSIGKeys(
+	ctx context.Context,
+	helper *helper.Helper,
+	instance *designatev1beta1.DesignateBackendbind9,
+	multipoolConfig *designate.MultipoolConfig,
+) (map[string]*designate.TSIGKey, error) {
+	Log := r.GetLogger(ctx)
+
+	osclient, err := designate.GetOpenstackClient(ctx, instance.Namespace, helper)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get OpenStack client: %w", err)
+	}
+
+	// Get pool name -> UUID mapping
+	designateInstance, err := r.getDesignateCR(ctx, helper, instance)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Designate CR: %w", err)
+	}
+
+	poolNameToID, err := designate.GetPoolNameToIDMap(ctx, helper, instance.Namespace, designateInstance)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get pool name-to-ID mapping: %w", err)
+	}
+
+	// Get all existing TSIG keys to avoid duplicate creation
+	existingKeys, err := designate.ListAllTSIGKeys(ctx, osclient)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list existing TSIG keys: %w", err)
+	}
+
+	existingKeysByName := make(map[string]*designate.TSIGKey)
+	for i := range existingKeys {
+		existingKeysByName[existingKeys[i].Name] = &existingKeys[i]
+	}
+
+	result := make(map[string]*designate.TSIGKey)
+
+	for _, pool := range multipoolConfig.Pools {
+		keyName := pool.Name + designate.PerPoolTSIGKeySuffix
+
+		poolUUID, exists := poolNameToID[pool.Name]
+		if !exists {
+			Log.Info(fmt.Sprintf("Pool %s not yet registered in Designate, skipping TSIG key creation", pool.Name))
+			continue
+		}
+
+		// Check if key already exists
+		if existing, ok := existingKeysByName[keyName]; ok {
+			Log.Info(fmt.Sprintf("Using existing per-pool TSIG key for pool %s: %s (ID: %s)", pool.Name, keyName, existing.ID))
+			result[pool.Name] = existing
+			continue
+		}
+
+		// Create new per-pool TSIG key
+		secret, err := generateTSIGSecret()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate TSIG secret for pool %s: %w", pool.Name, err)
+		}
+
+		tsigKey, err := designate.CreateTSIGKey(ctx, osclient, designate.CreateTSIGKeyOpts{
+			Name:       keyName,
+			Algorithm:  "hmac-sha256",
+			Secret:     secret,
+			Scope:      "POOL",
+			ResourceID: poolUUID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create TSIG key for pool %s: %w", pool.Name, err)
+		}
+
+		Log.Info(fmt.Sprintf("Created per-pool TSIG key for pool %s: %s (ID: %s)", pool.Name, keyName, tsigKey.ID))
+		result[pool.Name] = tsigKey
+	}
+
+	return result, nil
+}
+
+// cleanupOrphanedPerPoolTSIGKeys deletes TSIG keys from Designate for pools that no longer exist in the config.
+func (r *DesignateBackendbind9Reconciler) cleanupOrphanedPerPoolTSIGKeys(
+	ctx context.Context,
+	helper *helper.Helper,
+	instance *designatev1beta1.DesignateBackendbind9,
+	multipoolConfig *designate.MultipoolConfig,
+) error {
+	Log := r.GetLogger(ctx)
+
+	osclient, err := designate.GetOpenstackClient(ctx, instance.Namespace, helper)
+	if err != nil {
+		return fmt.Errorf("failed to get OpenStack client for TSIG cleanup: %w", err)
+	}
+
+	existingKeys, err := designate.ListAllTSIGKeys(ctx, osclient)
+	if err != nil {
+		return fmt.Errorf("failed to list TSIG keys for cleanup: %w", err)
+	}
+
+	// Build set of expected per-pool key names
+	expectedKeys := make(map[string]bool)
+	for _, pool := range multipoolConfig.Pools {
+		expectedKeys[pool.Name+designate.PerPoolTSIGKeySuffix] = true
+	}
+
+	// Delete keys that have the per-pool suffix but aren't in the expected set
+	for _, key := range existingKeys {
+		if strings.HasSuffix(key.Name, designate.PerPoolTSIGKeySuffix) && !expectedKeys[key.Name] {
+			Log.Info(fmt.Sprintf("Deleting orphaned per-pool TSIG key: %s (ID: %s)", key.Name, key.ID))
+			err := designate.DeleteTSIGKeyByName(ctx, osclient, key.Name)
+			if err != nil {
+				Log.Error(err, fmt.Sprintf("Failed to delete orphaned TSIG key %s", key.Name))
+			}
+		}
+	}
+
+	return nil
+}
+
+// generatePerPoolTSIGConfig builds the BIND TSIG configuration with multiple per-pool key blocks
+func (r *DesignateBackendbind9Reconciler) generatePerPoolTSIGConfig(
+	tsigKeys map[string]*designate.TSIGKey,
+	mdnsIPs []string,
+) string {
+	var config strings.Builder
+
+	// Sort pool names for deterministic output
+	poolNames := make([]string, 0, len(tsigKeys))
+	for name := range tsigKeys {
+		poolNames = append(poolNames, name)
+	}
+	sort.Strings(poolNames)
+
+	// Add key definitions for each pool
+	for _, poolName := range poolNames {
+		key := tsigKeys[poolName]
+		if !designate.IsValidTSIGKeyName(key.Name) {
+			continue
+		}
+		fmt.Fprintf(&config, "key \"%s\" {\n", key.Name)
+		fmt.Fprintf(&config, "    algorithm %s;\n", key.Algorithm)
+		fmt.Fprintf(&config, "    secret \"%s\";\n", key.Secret)
+		config.WriteString("};\n\n")
+	}
+
+	// Add server blocks for each mdns IP with all keys
+	for _, mdnsIP := range mdnsIPs {
+		fmt.Fprintf(&config, "server %s {\n", mdnsIP)
+		config.WriteString("    keys {\n")
+		for _, poolName := range poolNames {
+			key := tsigKeys[poolName]
+			fmt.Fprintf(&config, "        %s;\n", key.Name)
+		}
+		config.WriteString("    };\n")
+		config.WriteString("};\n")
+	}
+
+	return config.String()
+}
+
 // generateTSIGConfig builds the BIND TSIG configuration file content
 func (r *DesignateBackendbind9Reconciler) generateTSIGConfig(
 	tsigKey *designate.TSIGKey,
 	mdnsIPs []string,
 ) string {
 	var config strings.Builder
+
+	if !designate.IsValidTSIGKeyName(tsigKey.Name) {
+		return ""
+	}
 
 	// Add key definition
 	fmt.Fprintf(&config, "key \"%s\" {\n", tsigKey.Name)
@@ -943,28 +1258,38 @@ func (r *DesignateBackendbind9Reconciler) generateTSIGConfig(
 	return config.String()
 }
 
-// getPoolConfigHash generates a hash of the multipool configuration.
-// This hash is used to detect when pool configuration changes, avoiding unnecessary TSIG updates.
+// computePoolConfigHash is a shared helper that sorts pool names and computes a hash.
+func (r *DesignateBackendbind9Reconciler) computePoolConfigHash(prefix string, poolNames []string, mdnsIPs []string) (string, error) {
+	sort.Strings(poolNames)
+	hashInput := prefix + strings.Join(poolNames, ",")
+	if len(mdnsIPs) > 0 {
+		hashInput += "|mdns:" + strings.Join(mdnsIPs, ",")
+	}
+	hash, err := util.ObjectHash(hashInput)
+	if err != nil {
+		return "", fmt.Errorf("failed to hash pool config: %w", err)
+	}
+	return hash, nil
+}
+
+// getPoolConfigHash generates a hash of non-default pools (for shared TSIG model).
 func (r *DesignateBackendbind9Reconciler) getPoolConfigHash(multipoolConfig *designate.MultipoolConfig) (string, error) {
-	// Create a simple string representation of pool names (non-default pools only)
 	var poolNames []string
 	for poolIdx, pool := range multipoolConfig.Pools {
 		if poolIdx > 0 { // Skip default pool (pool0)
 			poolNames = append(poolNames, pool.Name)
 		}
 	}
+	return r.computePoolConfigHash("", poolNames, nil)
+}
 
-	// Sort for consistent ordering
-	sort.Strings(poolNames)
-
-	// Hash the sorted pool names
-	hashInput := strings.Join(poolNames, ",")
-	hash, err := util.ObjectHash(hashInput)
-	if err != nil {
-		return "", fmt.Errorf("failed to hash pool config: %w", err)
+// getPerPoolConfigHash generates a hash including ALL pools and mDNS IPs (for per-pool TSIG model).
+func (r *DesignateBackendbind9Reconciler) getPerPoolConfigHash(multipoolConfig *designate.MultipoolConfig, mdnsIPs []string) (string, error) {
+	var poolNames []string
+	for _, pool := range multipoolConfig.Pools {
+		poolNames = append(poolNames, pool.Name)
 	}
-
-	return hash, nil
+	return r.computePoolConfigHash("per-pool:", poolNames, mdnsIPs)
 }
 
 // createOrUpdateTSIGSecretWithHash creates or updates the TSIG secret with pool config hash annotation
@@ -992,6 +1317,8 @@ func (r *DesignateBackendbind9Reconciler) createOrUpdateTSIGSecretWithHash(
 
 	_, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), tsigSecret, func() error {
 		tsigSecret.Type = corev1.SecretTypeOpaque
+		// Clear existing Data to remove any leftover keys (e.g. tsigkey-ids.json from per-pool mode)
+		tsigSecret.Data = nil
 		tsigSecret.StringData = map[string]string{
 			"tsigkeys.conf": tsigConfigContent,
 		}
@@ -999,6 +1326,7 @@ func (r *DesignateBackendbind9Reconciler) createOrUpdateTSIGSecretWithHash(
 			tsigSecret.Annotations = make(map[string]string)
 		}
 		tsigSecret.Annotations["pool-config-hash"] = poolConfigHash
+		delete(tsigSecret.Annotations, "tsig-mode")
 		return controllerutil.SetControllerReference(instance, tsigSecret, r.Scheme)
 	})
 

--- a/internal/designate/const.go
+++ b/internal/designate/const.go
@@ -105,6 +105,12 @@ const (
 	// SharedTSIGKeyName is the name of the shared TSIG key used for all non-default pools
 	SharedTSIGKeyName = "multipool-shared-key"
 
+	// PerPoolTSIGKeySuffix is the suffix appended to pool names for per-pool TSIG keys
+	PerPoolTSIGKeySuffix = "-tsig-key"
+
+	// TSIGKeyIDsDataKey is the key in the TSIG Secret that stores the pool-name to tsigkey-id JSON mapping
+	TSIGKeyIDsDataKey = "tsigkey-ids.json"
+
 	// ACConsumerFinalizer is added to AC secrets that designate is actively consuming
 	ACConsumerFinalizer = "openstack.org/designateapi-ac-consumer"
 

--- a/internal/designate/generate_bind9_pools_yaml.go
+++ b/internal/designate/generate_bind9_pools_yaml.go
@@ -216,7 +216,8 @@ func validateMultipoolConfig(config *MultipoolConfig, azAwareMode designatev1.De
 			if pool.View == "" {
 				return fmt.Errorf("%w: pool %s", ErrPoolMissingView, pool.Name)
 			}
-			// TODO: Validate pool TSIGKeyID is non-empty once per-pool TSIG keys are implemented
+			// TSIGKeyID validation is handled at runtime — keys are created after pools
+			// are registered in Designate (two-pass flow in reconcileTSIGSecrets).
 		}
 	}
 
@@ -228,8 +229,9 @@ func validateMultipoolConfig(config *MultipoolConfig, azAwareMode designatev1.De
 	return nil
 }
 
-// GeneratePoolsYamlDataAndHash sorts all pool resources to get the correct hash every time
-func GeneratePoolsYamlDataAndHash(BindMap, MdnsMap map[string]string, nsRecords []designatev1.DesignateNSRecord, multipoolConfig *MultipoolConfig, externalBinds map[string][]ExternalBind, externalMasterServiceIPs map[string][]string) (string, string, error) {
+// GeneratePoolsYamlDataAndHash sorts all pool resources to get the correct hash every time.
+// tsigKeyIDs is a map of pool-name -> Designate TSIG key UUID for per-pool TSIG mode (nil if not used).
+func GeneratePoolsYamlDataAndHash(BindMap, MdnsMap map[string]string, nsRecords []designatev1.DesignateNSRecord, multipoolConfig *MultipoolConfig, externalBinds map[string][]ExternalBind, externalMasterServiceIPs map[string][]string, tsigKeyIDs map[string]string) (string, string, error) {
 	masterHosts := make([]string, 0, len(MdnsMap))
 	for _, host := range MdnsMap {
 		masterHosts = append(masterHosts, host)
@@ -246,7 +248,7 @@ func GeneratePoolsYamlDataAndHash(BindMap, MdnsMap map[string]string, nsRecords 
 		pools = []Pool{pool}
 	} else {
 		var err error
-		pools, err = generateMultiplePools(BindMap, masterHosts, multipoolConfig)
+		pools, err = generateMultiplePools(BindMap, masterHosts, multipoolConfig, tsigKeyIDs)
 		if err != nil {
 			return "", "", err
 		}
@@ -398,7 +400,7 @@ func generateDefaultPool(BindMap map[string]string, masterHosts []string, nsReco
 	return pool, nil
 }
 
-func generateMultiplePools(BindMap map[string]string, masterHosts []string, multipoolConfig *MultipoolConfig) ([]Pool, error) {
+func generateMultiplePools(BindMap map[string]string, masterHosts []string, multipoolConfig *MultipoolConfig, tsigKeyIDs map[string]string) ([]Pool, error) {
 	// Sort pools by name for stable ordering
 	sortedPools := make([]PoolConfig, len(multipoolConfig.Pools))
 	copy(sortedPools, multipoolConfig.Pools)
@@ -431,10 +433,16 @@ func generateMultiplePools(BindMap map[string]string, masterHosts []string, mult
 		masters := createMasters(masterHosts)
 		targets := make([]Target, poolConfig.BindReplicas)
 		nameservers := make([]Nameserver, poolConfig.BindReplicas)
+
+		var tsigKeyID string
+		if tsigKeyIDs != nil {
+			tsigKeyID = tsigKeyIDs[poolConfig.Name]
+		}
+
 		for i := int32(0); i < poolConfig.BindReplicas; i++ {
 			globalIndex := bindIndex - int(poolConfig.BindReplicas) + int(i)
 			description := fmt.Sprintf("BIND9 Server for pool %s (%s)", poolConfig.Name, poolBindIPs[i])
-			targets[i], nameservers[i] = createTargetAndNameserver(poolBindIPs[i], globalIndex, masters, description, poolConfig.View, "")
+			targets[i], nameservers[i] = createTargetAndNameserver(poolBindIPs[i], globalIndex, masters, description, poolConfig.View, tsigKeyID)
 		}
 
 		attributes := poolConfig.Attributes

--- a/internal/designate/generate_bind9_pools_yaml_test.go
+++ b/internal/designate/generate_bind9_pools_yaml_test.go
@@ -353,7 +353,7 @@ func TestGenerateMultiplePools(t *testing.T) {
 		},
 	}
 
-	pools, err := generateMultiplePools(bindMap, masterHosts, multipoolConfig)
+	pools, err := generateMultiplePools(bindMap, masterHosts, multipoolConfig, nil)
 	if err != nil {
 		t.Fatalf("generateMultiplePools() error = %v", err)
 	}
@@ -434,7 +434,7 @@ func TestMultipoolRequiresNSRecordsPerPool(t *testing.T) {
 		},
 	}
 
-	_, err := generateMultiplePools(bindMap, masterHosts, multipoolConfigMissingNS)
+	_, err := generateMultiplePools(bindMap, masterHosts, multipoolConfigMissingNS, nil)
 	if err == nil {
 		t.Fatal("expected error when pool is missing NS records in multipool mode, got nil")
 	}
@@ -790,7 +790,7 @@ func TestGenerateMultiplePoolsWithView(t *testing.T) {
 		},
 	}
 
-	pools, err := generateMultiplePools(bindMap, masterHosts, multipoolConfig)
+	pools, err := generateMultiplePools(bindMap, masterHosts, multipoolConfig, nil)
 	if err != nil {
 		t.Fatalf("generateMultiplePools() error = %v", err)
 	}
@@ -842,7 +842,7 @@ func TestGenerateMultiplePoolsViewOmittedWhenEmpty(t *testing.T) {
 		},
 	}
 
-	pools, err := generateMultiplePools(bindMap, masterHosts, multipoolConfig)
+	pools, err := generateMultiplePools(bindMap, masterHosts, multipoolConfig, nil)
 	if err != nil {
 		t.Fatalf("generateMultiplePools() error = %v", err)
 	}
@@ -1073,5 +1073,223 @@ func TestTemplateRenderingOmitsEmptyViewAndTSIG(t *testing.T) {
 
 	if strings.Contains(output, "tsigkey_id:") {
 		t.Errorf("expected rendered output to NOT contain 'tsigkey_id:' when TSIGKeyID is empty, got:\n%s", output)
+	}
+}
+
+func TestGenerateMultiplePoolsWithTSIGKeyIDs(t *testing.T) {
+	bindMap := map[string]string{
+		"bind_address_0": "192.168.1.10",
+		"bind_address_1": "192.168.1.11",
+		"bind_address_2": "192.168.1.12",
+		"bind_address_3": "192.168.1.13",
+	}
+	masterHosts := []string{"192.168.1.20"}
+
+	multipoolConfig := &MultipoolConfig{
+		Pools: []PoolConfig{
+			{
+				Name:         "default",
+				Description:  "Default Pool",
+				BindReplicas: 2,
+				View:         "default-view",
+				NSRecords: []designatev1.DesignateNSRecord{
+					{Hostname: "ns1.example.org.", Priority: 1},
+				},
+			},
+			{
+				Name:         "pool1",
+				Description:  "Pool 1",
+				BindReplicas: 2,
+				View:         "az1-view",
+				NSRecords: []designatev1.DesignateNSRecord{
+					{Hostname: "ns2.example.org.", Priority: 1},
+				},
+			},
+		},
+	}
+
+	tsigKeyIDs := map[string]string{
+		"default": "aaaaaaaa-1111-2222-3333-444444444444",
+		"pool1":   "bbbbbbbb-1111-2222-3333-444444444444",
+	}
+
+	pools, err := generateMultiplePools(bindMap, masterHosts, multipoolConfig, tsigKeyIDs)
+	if err != nil {
+		t.Fatalf("generateMultiplePools() error = %v", err)
+	}
+
+	if len(pools) != 2 {
+		t.Fatalf("expected 2 pools, got %d", len(pools))
+	}
+
+	// Verify tsigkey_id is set on default pool targets and nameservers
+	for _, target := range pools[0].Targets {
+		if target.TSIGKeyID != "aaaaaaaa-1111-2222-3333-444444444444" {
+			t.Errorf("expected default pool target TSIGKeyID 'aaaaaaaa-...', got '%s'", target.TSIGKeyID)
+		}
+	}
+	for _, ns := range pools[0].Nameservers {
+		if ns.TSIGKeyID != "aaaaaaaa-1111-2222-3333-444444444444" {
+			t.Errorf("expected default pool nameserver TSIGKeyID 'aaaaaaaa-...', got '%s'", ns.TSIGKeyID)
+		}
+	}
+
+	// Verify tsigkey_id is set on pool1 targets and nameservers
+	for _, target := range pools[1].Targets {
+		if target.TSIGKeyID != "bbbbbbbb-1111-2222-3333-444444444444" {
+			t.Errorf("expected pool1 target TSIGKeyID 'bbbbbbbb-...', got '%s'", target.TSIGKeyID)
+		}
+	}
+	for _, ns := range pools[1].Nameservers {
+		if ns.TSIGKeyID != "bbbbbbbb-1111-2222-3333-444444444444" {
+			t.Errorf("expected pool1 nameserver TSIGKeyID 'bbbbbbbb-...', got '%s'", ns.TSIGKeyID)
+		}
+	}
+}
+
+func TestGenerateMultiplePoolsPartialTSIGKeyIDs(t *testing.T) {
+	bindMap := map[string]string{
+		"bind_address_0": "192.168.1.10",
+		"bind_address_1": "192.168.1.11",
+	}
+	masterHosts := []string{"192.168.1.20"}
+
+	multipoolConfig := &MultipoolConfig{
+		Pools: []PoolConfig{
+			{
+				Name:         "default",
+				Description:  "Default Pool",
+				BindReplicas: 1,
+				NSRecords: []designatev1.DesignateNSRecord{
+					{Hostname: "ns1.example.org.", Priority: 1},
+				},
+			},
+			{
+				Name:         "pool1",
+				Description:  "Pool 1",
+				BindReplicas: 1,
+				NSRecords: []designatev1.DesignateNSRecord{
+					{Hostname: "ns2.example.org.", Priority: 1},
+				},
+			},
+		},
+	}
+
+	// Only default has a tsigkey_id (pool1 not yet registered)
+	tsigKeyIDs := map[string]string{
+		"default": "aaaaaaaa-1111-2222-3333-444444444444",
+	}
+
+	pools, err := generateMultiplePools(bindMap, masterHosts, multipoolConfig, tsigKeyIDs)
+	if err != nil {
+		t.Fatalf("generateMultiplePools() error = %v", err)
+	}
+
+	// Default pool should have tsigkey_id
+	for _, target := range pools[0].Targets {
+		if target.TSIGKeyID != "aaaaaaaa-1111-2222-3333-444444444444" {
+			t.Errorf("expected default pool target TSIGKeyID set, got '%s'", target.TSIGKeyID)
+		}
+	}
+
+	// Pool1 should have empty tsigkey_id (not yet in mapping)
+	for _, target := range pools[1].Targets {
+		if target.TSIGKeyID != "" {
+			t.Errorf("expected pool1 target TSIGKeyID empty when not in mapping, got '%s'", target.TSIGKeyID)
+		}
+	}
+}
+
+func TestTemplateRenderingWithPerPoolTSIGKeyIDs(t *testing.T) {
+	pools := []Pool{
+		{
+			Name:        "default",
+			Description: "Default Pool",
+			Attributes:  map[string]string{},
+			NSRecords: []designatev1.DesignateNSRecord{
+				{Hostname: "ns1.example.org.", Priority: 1},
+			},
+			Nameservers: []Nameserver{
+				{Host: "192.168.1.10", Port: 53, TSIGKeyID: "default-key-uuid"},
+			},
+			Targets: []Target{
+				{
+					Type:        "bind9",
+					Description: "BIND9 Server",
+					TSIGKeyID:   "default-key-uuid",
+					Masters:     []Master{{Host: "192.168.1.20", Port: 5354}},
+					Options: Options{
+						Host:        "192.168.1.10",
+						Port:        53,
+						RNDCHost:    "192.168.1.10",
+						RNDCPort:    953,
+						RNDCKeyFile: "/etc/designate/rndc-keys/rndc-key-0",
+						View:        "default-view",
+					},
+				},
+			},
+		},
+		{
+			Name:        "pool1",
+			Description: "Pool 1",
+			Attributes:  map[string]string{"az": "1"},
+			NSRecords: []designatev1.DesignateNSRecord{
+				{Hostname: "ns2.example.org.", Priority: 1},
+			},
+			Nameservers: []Nameserver{
+				{Host: "192.168.1.11", Port: 53, TSIGKeyID: "pool1-key-uuid"},
+			},
+			Targets: []Target{
+				{
+					Type:        "bind9",
+					Description: "BIND9 Server",
+					TSIGKeyID:   "pool1-key-uuid",
+					Masters:     []Master{{Host: "192.168.1.20", Port: 5354}},
+					Options: Options{
+						Host:        "192.168.1.11",
+						Port:        53,
+						RNDCHost:    "192.168.1.11",
+						RNDCPort:    953,
+						RNDCKeyFile: "/etc/designate/rndc-keys/rndc-key-1",
+						View:        "az1-view",
+					},
+				},
+			},
+		},
+	}
+
+	tmpl, err := template.ParseFiles("../../templates/designatepoolmanager/config/pools.yaml.tmpl")
+	if err != nil {
+		t.Fatalf("failed to parse template: %v", err)
+	}
+
+	var buf strings.Builder
+	err = tmpl.Execute(&buf, pools)
+	if err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+
+	output := buf.String()
+
+	// Both pools should have tsigkey_id rendered
+	if !strings.Contains(output, "tsigkey_id: default-key-uuid") {
+		t.Errorf("expected rendered output to contain 'tsigkey_id: default-key-uuid', got:\n%s", output)
+	}
+	if !strings.Contains(output, "tsigkey_id: pool1-key-uuid") {
+		t.Errorf("expected rendered output to contain 'tsigkey_id: pool1-key-uuid', got:\n%s", output)
+	}
+
+	// Both pools should have view rendered
+	if !strings.Contains(output, "view: default-view") {
+		t.Errorf("expected rendered output to contain 'view: default-view', got:\n%s", output)
+	}
+	if !strings.Contains(output, "view: az1-view") {
+		t.Errorf("expected rendered output to contain 'view: az1-view', got:\n%s", output)
+	}
+
+	// tsigkey_id should appear in both nameservers and targets for each pool (4 total)
+	if strings.Count(output, "tsigkey_id:") < 4 {
+		t.Errorf("expected at least 4 tsigkey_id entries (nameserver+target for 2 pools), got %d in:\n%s",
+			strings.Count(output, "tsigkey_id:"), output)
 	}
 }

--- a/internal/designate/tsigkeys.go
+++ b/internal/designate/tsigkeys.go
@@ -17,9 +17,17 @@ package designate
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/openstack"
 )
+
+var validTSIGKeyName = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+// IsValidTSIGKeyName checks that a TSIG key name is safe for injection into BIND config files.
+func IsValidTSIGKeyName(name string) bool {
+	return len(name) > 0 && validTSIGKeyName.MatchString(name)
+}
 
 // TODO: Replace this custom implementation with upstream Gophercloud support when available.
 // This package implements TSIG key operations that are currently missing from Gophercloud.
@@ -28,12 +36,13 @@ import (
 
 // TSIGKey represents a TSIG (Transaction Signature) key for DNS authentication
 type TSIGKey struct {
+	ID        string `json:"id"`
 	Name      string `json:"name"`
 	Algorithm string `json:"algorithm"` // e.g., "hmac-sha256"
 	Secret    string `json:"secret"`    // Base64-encoded key
 }
 
-// ListAllTSIGKeys retrieves all TSIG keys (no filtering)
+// ListAllTSIGKeys retrieves all TSIG keys with full details including ID
 func ListAllTSIGKeys(
 	ctx context.Context,
 	osclient *openstack.OpenStack,
@@ -88,29 +97,23 @@ func DeleteTSIGKeyByName(
 		return fmt.Errorf("failed to get DNS client: %w", err)
 	}
 
-	// Get all TSIG keys with full details including ID
-	allKeys, err := ListAllTSIGKeysWithID(ctx, osclient)
+	allKeys, err := ListAllTSIGKeys(ctx, osclient)
 	if err != nil {
 		return fmt.Errorf("failed to list TSIG keys: %w", err)
 	}
 
-	// Find the key with matching name
 	var keyID string
 	for _, key := range allKeys {
-		if keyName, ok := key["name"].(string); ok && keyName == name {
-			if id, ok := key["id"].(string); ok {
-				keyID = id
-				break
-			}
+		if key.Name == name {
+			keyID = key.ID
+			break
 		}
 	}
 
 	if keyID == "" {
-		// Key not found, nothing to delete
 		return nil
 	}
 
-	// Delete the TSIG key
 	url := dnsClient.ServiceURL("tsigkeys", keyID)
 	_, err = dnsClient.Delete(ctx, url, nil)
 	if err != nil {
@@ -118,30 +121,6 @@ func DeleteTSIGKeyByName(
 	}
 
 	return nil
-}
-
-// ListAllTSIGKeysWithID retrieves all TSIG keys with full details including ID
-func ListAllTSIGKeysWithID(
-	ctx context.Context,
-	osclient *openstack.OpenStack,
-) ([]map[string]interface{}, error) {
-	dnsClient, err := GetDNSClient(osclient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get DNS client: %w", err)
-	}
-
-	url := dnsClient.ServiceURL("tsigkeys")
-
-	var result struct {
-		TSIGKeys []map[string]interface{} `json:"tsigkeys"`
-	}
-
-	_, err = dnsClient.Get(ctx, url, &result, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list TSIG keys: %w", err)
-	}
-
-	return result.TSIGKeys, nil
 }
 
 // CreateTSIGKeyOpts represents options for creating a TSIG key
@@ -185,11 +164,16 @@ func CreateTSIGKey(
 		return nil, fmt.Errorf("failed to create TSIG key: %w", err)
 	}
 
-	// Extract TSIGKey fields from response
+	id, _ := result["id"].(string)
+	name, _ := result["name"].(string)
+	algorithm, _ := result["algorithm"].(string)
+	secret, _ := result["secret"].(string)
+
 	tsigKey := &TSIGKey{
-		Name:      result["name"].(string),
-		Algorithm: result["algorithm"].(string),
-		Secret:    result["secret"].(string),
+		ID:        id,
+		Name:      name,
+		Algorithm: algorithm,
+		Secret:    secret,
 	}
 
 	return tsigKey, nil

--- a/test/functional/designate_controller_test.go
+++ b/test/functional/designate_controller_test.go
@@ -848,12 +848,12 @@ var _ = Describe("Designate controller", func() {
 				allNSRecords = append(allNSRecords, nsRecords...)
 			}
 
-			_, poolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, allNSRecords, nil, make(map[string][]designate.ExternalBind), make(map[string][]string))
+			_, poolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, allNSRecords, nil, make(map[string][]designate.ExternalBind), make(map[string][]string), nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			// we used to have inconsistent ordering, so generate the pools.yaml 10 times and make sure it is has exactly the same content
 			for range 10 {
-				_, newPoolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, allNSRecords, nil, make(map[string][]designate.ExternalBind), make(map[string][]string))
+				_, newPoolsYamlHash, err := designate.GeneratePoolsYamlDataAndHash(bindConfigMap.Data, mdnsConfigMap.Data, allNSRecords, nil, make(map[string][]designate.ExternalBind), make(map[string][]string), nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(poolsYamlHash).Should(Equal(newPoolsYamlHash))
 			}


### PR DESCRIPTION
Replace the shared TSIG key model with per-pool keys when AZAwareMode=Enabled. Each pool (including default) gets its own TSIG key with scope=POOL and resource_id set to the actual pool UUID from Designate.

Implement the two-pass creation flow: pools are created without tsigkey_id, pool UUIDs are retrieved, TSIG keys are created per pool, then pools.yaml is regenerated with tsigkey_id populated.

Add lifecycle management: cleanup orphaned TSIG keys when pools are removed, clean transition between per-pool and shared modes. The shared TSIG model remains unchanged when AZAwareMode is not enabled.

Add unit tests for pool generation with TSIG key IDs.