### PR TITLE
Set service_type in [keystone_authtoken] for access rule validation

### DIFF
--- a/templates/designateapi/config/designate.conf
+++ b/templates/designateapi/config/designate.conf
@@ -22,3 +22,4 @@ region_name={{ .Region }}
 www_authenticate_uri={{ .KeystonePublicURL }}
 auth_url={{ .KeystoneInternalURL }}
 interface=internal
+service_type=dns

--- a/test/functional/designateapi_controller_test.go
+++ b/test/functional/designateapi_controller_test.go
@@ -213,6 +213,9 @@ var _ = Describe("DesignateAPI controller", func() {
 			Expect(conf).Should(
 				ContainSubstring(fmt.Sprintf(
 					"region_name=%s", keystoneAPI.Status.Region)))
+
+			Expect(conf).Should(
+				ContainSubstring("service_type=dns"))
 		})
 
 		It("should create a Secret with customServiceConfig input", func() {


### PR DESCRIPTION
Without service_type configured, keystonemiddleware cannot validate application credentials with custom access rules, causing HTTP 401 for end users.

Closes: [OSPRH-22365](https://redhat.atlassian.net/browse/OSPRH-22365)