### PR TITLE
Mount TSIG secret on pool0 in AZ-aware mode

### DIFF
--- a/internal/controller/designatebackendbind9_controller.go
+++ b/internal/controller/designatebackendbind9_controller.go
@@ -646,7 +646,7 @@ func (r *DesignateBackendbind9Reconciler) reconcileSingleStatefulSet(
 
 	// Define a new StatefulSet object
 	// Use default bind IP ConfigMap for single-pool mode
-	deplDef, err := designatebackendbind9.StatefulSet(instance, inputHash, serviceLabels, serviceAnnotations, topology, instance.Name, designate.BindPredIPConfigMap)
+	deplDef, err := designatebackendbind9.StatefulSet(instance, inputHash, serviceLabels, serviceAnnotations, topology, instance.Name, designate.BindPredIPConfigMap, false)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/designatebackendbind9_multipool.go
+++ b/internal/controller/designatebackendbind9_multipool.go
@@ -384,6 +384,10 @@ func (r *DesignateBackendbind9Reconciler) reconcileMultipoolStatefulSets(
 	var requeueNeeded bool
 	var requeueResult ctrl.Result
 
+	// Check AZ-aware mode — pool0 needs TSIG in AZ-aware mode
+	designateInstance, azErr := r.getDesignateCR(ctx, helper, instance)
+	azAwareMode := azErr == nil && designateInstance.Spec.AZAwareMode == designatev1beta1.AZModeEnabled
+
 	// Track expected StatefulSet names for cleanup
 	expectedStatefulSets := make(map[string]bool)
 
@@ -407,13 +411,17 @@ func (r *DesignateBackendbind9Reconciler) reconcileMultipoolStatefulSets(
 		// selector immutability issues during single-pool to multipool migrations and vice versa.
 		// Pools are identified by StatefulSet name pattern instead (pool0=instance.Name, pool1+=instance.Name-pool1, etc.)
 
-		// Add TSIG secret resourceVersion to annotations for non-default pools, so pods restart
-		// when their own pool's TSIG secret changes. Each pool has its own secret.
+		// In AZ-aware mode all pools need TSIG (each pool gets its own Secret); otherwise only
+		// non-default pools.
+		includeTSIG := azAwareMode || poolIdx > 0
+
+		// Add TSIG secret resourceVersion to annotations, so pods restart when their own pool's
+		// TSIG secret changes. Each pool has its own secret.
 		poolAnnotations := make(map[string]string)
 		for k, v := range serviceAnnotations {
 			poolAnnotations[k] = v
 		}
-		if poolIdx > 0 {
+		if includeTSIG {
 			tsigSecret := &corev1.Secret{}
 			err := helper.GetClient().Get(ctx, types.NamespacedName{Name: tsigSecretNameForPool(instance.Name, poolIdx), Namespace: instance.Namespace}, tsigSecret)
 			if err == nil {
@@ -434,7 +442,7 @@ func (r *DesignateBackendbind9Reconciler) reconcileMultipoolStatefulSets(
 		} else {
 			poolBindIPConfigMap = fmt.Sprintf("%s-pool%d", designate.BindPredIPConfigMap, poolIdx)
 		}
-		deplDef, err := designatebackendbind9.StatefulSet(poolInstance, inputHash, serviceLabels, poolAnnotations, topology, poolStatefulSetName, poolBindIPConfigMap)
+		deplDef, err := designatebackendbind9.StatefulSet(poolInstance, inputHash, serviceLabels, poolAnnotations, topology, poolStatefulSetName, poolBindIPConfigMap, includeTSIG)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/designatebackendbind9/deployment.go
+++ b/internal/designatebackendbind9/deployment.go
@@ -17,7 +17,6 @@ package designatebackendbind9
 
 import (
 	"fmt"
-	"strings"
 
 	designatev1beta1 "github.com/openstack-k8s-operators/designate-operator/api/v1beta1"
 	designate "github.com/openstack-k8s-operators/designate-operator/internal/designate"
@@ -53,6 +52,7 @@ func StatefulSet(
 	topology *topologyv1.Topology,
 	statefulSetName string,
 	bindIPConfigMapName string,
+	includeTSIG bool,
 ) (*appsv1.StatefulSet, error) {
 
 	// TODO(beagles): Dbl check that running as the default kolla/tcib user works okay here. Permissions on some of the
@@ -91,17 +91,12 @@ func StatefulSet(
 	envVars["KOLLA_CONFIG_STRATEGY"] = env.SetValue("COPY_ALWAYS")
 	envVars["CONFIG_HASH"] = env.SetValue(configHash)
 
-	// Determine if TSIG is needed based on StatefulSet name
-	// Only non-default pools (pool1, pool2, etc.) need TSIG, not pool0 (default pool)
+	// Each pool gets its own TSIG secret, named after its own StatefulSet, since each pool is a
+	// separate BIND process that only ever needs its own key (see tsigSecretNameForPool in
+	// designatebackendbind9_multipool.go, which the caller uses to decide includeTSIG).
 	var tsigSecretName string
-	var includeTSIG bool
-	if statefulSetName != instance.Name && !strings.Contains(statefulSetName, "-pool0") {
-		// This is a non-default pool StatefulSet, add TSIG support.
-		// Each pool gets its own TSIG secret, named after its own StatefulSet, since each pool
-		// is a separate BIND process that only ever needs its own key (see
-		// tsigSecretNameForPool in designatebackendbind9_multipool.go).
+	if includeTSIG {
 		tsigSecretName = statefulSetName + designate.TsigSecretSuffix
-		includeTSIG = true
 	}
 
 	// Use instance.Name for secret references (shared across pools in multipool mode)


### PR DESCRIPTION
Mount TSIG secret on pool0 in AZ-aware mode

In AZ-aware mode every pool (including the default) has its own
per-pool TSIG key, but the StatefulSet for pool0 was not mounting the
TSIG secret and its pods were not restarted on TSIG changes.

Move the TSIG inclusion decision from the StatefulSet builder (which
was inferring it from the StatefulSet name) to the caller, which
already knows the pool index and AZ mode. The StatefulSet function now
takes an explicit includeTSIG parameter again, but keeps deriving the
secret name from the pool's own StatefulSet name (via
tsigSecretNameForPool) rather than the old shared instance name, so
pool0 gets its own correctly-scoped Secret instead of a merged one.

Verified on a live cluster: pool0 now mounts its own TSIG secret
alongside pool1's separate secret, and both pods stay Ready.

Depends-On: https://github.com/openstack-k8s-operators/designate-operator/pull/495