### PR TITLE
Remove deprecated webhook.Defaulter/Validator interface assertions

### DIFF
--- a/api/v1beta1/designate_webhook.go
+++ b/api/v1beta1/designate_webhook.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -59,8 +58,6 @@ func SetupDesignateDefaults(defaults DesignateDefaults) {
 	designateDefaults = defaults
 	designatelog.Info("Designate defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Defaulter = &Designate{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Designate) Default() {
@@ -159,8 +156,6 @@ func (spec *DesignateSpecBase) validateDeprecatedFieldsUpdate(old DesignateSpecB
 	deprecatedFields := spec.getDeprecatedFields(&old)
 	return common_webhook.ValidateDeprecatedFieldsUpdate(deprecatedFields, basePath)
 }
-
-var _ webhook.Validator = &Designate{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Designate) ValidateCreate() (admission.Warnings, error) {


### PR DESCRIPTION
These compile-time assertions reference webhook.Defaulter and webhook.Validator interfaces that are removed in controller-runtime v0.21 (OCP 4.20). The assertions are dead code — webhook registration already uses CustomDefaulter/CustomValidator in internal/webhook/.

Removing them makes the API module forward-compatible with CR v0.21 so that consumers (like openstack-operator) can bump controller-runtime without needing replace directives for this operator.

Jira: [OSPRH-32989](https://redhat.atlassian.net/browse/OSPRH-32989)