### PR TITLE
Fix flaky external master service functional test

### DIFF
--- a/test/functional/designate_controller_test.go
+++ b/test/functional/designate_controller_test.go
@@ -90,6 +90,19 @@ func createAndSimulateNSRecordsConfigMap(
 	DeferCleanup(k8sClient.Delete, ctx, configMap)
 }
 func simulateCentralReadyCount(designateName types.NamespacedName, readyCount int32) {
+	// Patching Designate.Status.DesignateCentralReadyCount directly only sticks for one
+	// reconcile: the Designate controller re-derives this field from the real
+	// DesignateCentral CR's Status.ReadyCount on every pass, so a bare status patch here
+	// gets clobbered back as soon as the next reconcile runs. Simulate readiness on the
+	// actual backing Deployment instead, so it flows durably through
+	// DesignateCentral.Status.ReadyCount -> Designate.Status.DesignateCentralReadyCount on
+	// every reconcile, the same way the rest of the suite simulates readiness elsewhere.
+	if readyCount > 0 {
+		th.SimulateDeploymentReplicaReady(types.NamespacedName{
+			Namespace: designateName.Namespace,
+			Name:      fmt.Sprintf("%s-central", designateName.Name),
+		})
+	}
 	Eventually(func(g Gomega) {
 		designate := GetDesignate(designateName)
 		designate.Status.DesignateCentralReadyCount = readyCount


### PR DESCRIPTION
simulateCentralReadyCount() patched Designate.Status.DesignateCentralReadyCount directly, once. The real reconciler re-derives that same field from the DesignateCentral CR's Status.ReadyCount on every pass, so the one-shot patch got clobbered back to 0 as soon as the next reconcile ran. Since pools.yaml is only regenerated while DesignateCentralReadyCount > 0, this left a narrow, accidental window in which pools.yaml could be written at all - freezing its content at whatever state happened to exist at that instant, regardless of what the test did afterward (e.g. assigning an external master service's ingress IP).

Simulate readiness on the actual backing DesignateCentral Deployment instead, via SimulateDeploymentReplicaReady, so it flows durably through Deployment.Status.ReadyReplicas -> DesignateCentral.Status.ReadyCount -> Designate.Status.DesignateCentralReadyCount on every reconcile, matching the pattern already used elsewhere in the suite (e.g. designate-api).